### PR TITLE
Delegate the creation of new samples from inbound shipments to queue

### DIFF
--- a/src/senaite/referral/queue/configure.zcml
+++ b/src/senaite/referral/queue/configure.zcml
@@ -7,4 +7,11 @@
   <include package=".listing"/>
   <include package=".viewlets"/>
 
+  <!-- Adapter for the creation of samples from inbound shipments -->
+  <adapter
+      name="task_create_sample_from_inbound"
+      factory=".tasks.CreateSampleFromInboundSampleAdapter"
+      provides="senaite.queue.interfaces.IQueuedTaskAdapter"
+      for="senaite.referral.interfaces.IInboundSample" />
+
 </configure>

--- a/src/senaite/referral/queue/tasks.py
+++ b/src/senaite/referral/queue/tasks.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+
+from bika.lims import api
+from bika.lims.utils.analysisrequest import create_analysisrequest
+from bika.lims.workflow import doActionFor
+
+from senaite.queue.interfaces import IQueuedTaskAdapter
+from senaite.referral import logger
+from senaite.referral.interfaces import IInboundSample
+from senaite.referral.workflow.inboundsample.events import get_new_sample_info
+from zope.component import adapter
+from zope.interface import implementer
+
+
+@implementer(IQueuedTaskAdapter)
+@adapter(IInboundSample)
+class CreateSampleFromInboundSampleAdapter(object):
+    """Adapter for the creation of the sample counterpart of an inbound sample
+    """
+
+    def __init__(self, context):
+        self.context = context
+
+    def process(self, task):
+        """Transition the objects from the task
+        """
+        # Do nothing if it has a 'real' sample assigned already
+        if self.context.getRawSample():
+            path = api.get_path(self.context)
+            logger.warn("Inbound sample with a Sample assigned already: {}"
+                        .format(path))
+            return True
+
+        # Extract the data to assign to the 'new' sample
+        values = task.get("data", None)
+        if not values:
+            logger.warn("No 'data' payload")
+            values = get_new_sample_info(self.context)
+            task.update({"data": values})
+
+        # Create the sample
+        client = values.pop("Client")
+        client = api.get_object_by_uid(client)
+        services = values.pop("analyses")
+        request = api.get_request()
+        sample = create_analysisrequest(client, request, values, services)
+
+        # Associate this new Sample with the Inbound Sample
+        self.context.setSample(sample)
+
+        # Auto-receive the sample object
+        doActionFor(sample, "receive")
+
+        # Try to to receive the whole shipment
+        shipment = sample.getInboundShipment()
+        doActionFor(shipment, "receive_inbound_shipment")
+
+        return True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When the action "receive" is taken for samples from an inbound shipment, the system looks for the necessary objects for the creation of the counterpart sample and once resolved, proceeds with the creation of the sample object.  Both processes are high-consuming and often end up with transaction conflicts.

This Pull Request improves the reception of inbound samples so the creation of the sample counterpart is delegated to the queue if possible. System extracts the necessary objects for the sample that will eventually be created and injects this information as metadata for a new queued task that will be in charge to effectively create the sample object.

## Current behavior before PR

The reception of inbound samples do not finish correctly because it takes too much time for the processes involved to complete

## Desired behavior after PR is merged

The reception of inbound samples finish correctly because the processes involved are partially handled by the queue

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html