### PR TITLE
Sort samples by their ID in the shipment manifest PDF

### DIFF
--- a/src/senaite/referral/browser/inbound/templates/view.pt
+++ b/src/senaite/referral/browser/inbound/templates/view.pt
@@ -5,7 +5,7 @@
       lang="en"
       metal:use-macro="here/main_template/macros/master"
       i18n:domain="plone">
-<body>
+<body tal:define="portal_url nocall:context/portal_url;">
 
 <metal:description fill-slot="content-description"/>
 
@@ -30,7 +30,7 @@
       <div class="col-sm-12">
         <h3>
           <img i18n:attributes="title" title="Samples"
-               tal:attributes="src string:${view/portal_url}/++resource++bika.lims.images/sample.png"/>
+               tal:attributes="src string:${portal_url}/++resource++bika.lims.images/sample.png"/>
           <span i18n:translate="">Samples</span>
         </h3>
         <span tal:replace="structure python:view.render_samples_table()"/>

--- a/src/senaite/referral/browser/outbound/templates/view.pt
+++ b/src/senaite/referral/browser/outbound/templates/view.pt
@@ -5,7 +5,7 @@
       lang="en"
       metal:use-macro="here/main_template/macros/master"
       i18n:domain="plone">
-<body>
+<body tal:define="portal_url nocall:context/portal_url;">
 
 <metal:description fill-slot="content-description"/>
 
@@ -30,7 +30,7 @@
       <div class="col-sm-12">
         <h3>
           <img i18n:attributes="title" title="Samples"
-               tal:attributes="src string:${view/portal_url}/++resource++bika.lims.images/sample.png"/>
+               tal:attributes="src string:${portal_url}/++resource++bika.lims.images/sample.png"/>
           <span i18n:translate="">Samples</span>
         </h3>
         <span tal:replace="structure python:view.render_samples_table()"/>

--- a/src/senaite/referral/browser/shipment_manifest.py
+++ b/src/senaite/referral/browser/shipment_manifest.py
@@ -118,6 +118,12 @@ class ShipmentManifestTemplate(BaseView):
     def shipment(self):
         return self.context
 
+    def get_samples(self):
+        """Returns the samples of the shipment, sorted by id ascending
+        """
+        samples = self.shipment.getSamples()
+        return sorted(samples, key=lambda sample: sample.getId())
+
     def to_localized_time(self, date, **kw):
         """Converts the given date to a localized time string
         """

--- a/src/senaite/referral/browser/templates/shipment_manifest_template.pt
+++ b/src/senaite/referral/browser/templates/shipment_manifest_template.pt
@@ -180,7 +180,7 @@
             <th i18n:translate="">Date Sampled</th>
             <th i18n:translate="">Sample Type</th>
           </tr>
-          <tr tal:repeat="sample python:view.shipment.getSamples()">
+          <tr tal:repeat="sample python:view.get_samples()">
             <td class="align-middle text-left" tal:content="python:sample.getId()"/>
             <td class="align-middle text-left" tal:content="python:view.long_date(sample.getDateSampled())"/>
             <td class="align-middle text-left" tal:content="python:sample.getSampleType().Title()"/>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures the samples are sorted by their ID ascending in the shipment manifest (PDF):

![Captura de 2023-01-26 12-41-15](https://user-images.githubusercontent.com/832627/214827612-21455da8-8c84-4db1-b292-76d19ae6efc1.png)

## Current behavior before PR

Samples are not sorted by id in shipment manifest

## Desired behavior after PR is merged

Samples are sorted by id in shipment manifest

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html