### PR TITLE
Add Client Sample ID in the outbound shipment manifest PDF

### DIFF
--- a/src/senaite/referral/browser/templates/shipment_manifest_template.pt
+++ b/src/senaite/referral/browser/templates/shipment_manifest_template.pt
@@ -171,17 +171,29 @@
         <h2 i18n:translate="">Samples</h2>
         <table class="w-100 mb-0 noborder">
           <colgroup>
-            <col style="width:30%"/>
-            <col style="width:30%"/>
+            <col style="width:15%"/>
+            <col style="width:15%"/>
+            <col style="width:20%"/>
+            <col style="width:20%"/>
             <col style="width:30%"/>
           </colgroup>
           <tr>
-            <th i18n:translate="">Sample ID</th>
-            <th i18n:translate="">Date Sampled</th>
-            <th i18n:translate="">Sample Type</th>
+            <th i18n:translate="shipment_manifest_column_sample_id">
+              Sample ID
+            </th>
+            <th i18n:translate="shipment_manifest_column_client_sample_id">
+              Client SID
+            </th>
+            <th i18n:translate="shipment_manifest_column_date_sampled">
+              Date Sampled
+            </th>
+            <th i18n:translate="shipment_manifest_column_sample_type">
+              Sample Type
+            </th>
           </tr>
           <tr tal:repeat="sample python:view.get_samples()">
             <td class="align-middle text-left" tal:content="python:sample.getId()"/>
+            <td class="align-middle text-left" tal:content="python:sample.getClientSampleID()"/>
             <td class="align-middle text-left" tal:content="python:view.long_date(sample.getDateSampled())"/>
             <td class="align-middle text-left" tal:content="python:sample.getSampleType().Title()"/>
           </tr>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds a column for Client Sample ID (*Client SID*) in the outbound shipment manifest

![Captura de 2023-01-26 18-47-59](https://user-images.githubusercontent.com/832627/214910682-24007e22-a919-461d-8bf1-e87e5861bc84.png)


## Current behavior before PR

Client Sample ID is not displayed in shipment manifest

## Desired behavior after PR is merged

Client Sample ID is displayed in shipment manifest

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html