### PR TITLE
Allow to sort samples from inbound and outbound shipments

### DIFF
--- a/src/senaite/referral/browser/inbound/samples.py
+++ b/src/senaite/referral/browser/inbound/samples.py
@@ -61,7 +61,7 @@ class SamplesListingView(ListingView):
             }),
             ("sample_id", {
                 "title": _("Sample ID"),
-                "sortable": False,
+                "sortable": True,
             }),
             ("client", {
                 "title": _("Client"),
@@ -161,7 +161,7 @@ class SamplesListingView(ListingView):
             analyses = list(collections.OrderedDict.fromkeys(analyses))
             item.update({
                 "uid": api.get_uid(sample),
-                "sample_id": api.get_id(sample),
+                "sample_id": obj.getReferringID(),
                 "client": api.get_title(client),
                 "priority": sample.getPriority(),
                 "sample_type": api.get_id(sample_type),

--- a/src/senaite/referral/browser/outbound/samples.py
+++ b/src/senaite/referral/browser/outbound/samples.py
@@ -140,7 +140,6 @@ class SamplesListingView(ListingView):
             priority = priority_div.format(priority, priority_text)
             item["replace"]["priority"] = priority
 
-        item["getId"] = api.get_id(sample)
         item["getDateReceived"] = self.ulocalized_time(received, long_format=1)
         item["getDateSampled"] = self.ulocalized_time(sampled, long_format=1)
         return item

--- a/src/senaite/referral/browser/outbound/samples.py
+++ b/src/senaite/referral/browser/outbound/samples.py
@@ -57,7 +57,8 @@ class SamplesListingView(ListingView):
                 "title": _c("Sample ID"),
                 "attr": "getId",
                 "replace_url": "getURL",
-                "index": "getId"}),
+                "index": "getId",
+                "sortable": True}),
             ("getDateSampled", {
                 "title": _c("Date Sampled"),
                 "toggle": True}),
@@ -139,6 +140,7 @@ class SamplesListingView(ListingView):
             priority = priority_div.format(priority, priority_text)
             item["replace"]["priority"] = priority
 
+        item["getId"] = api.get_id(sample)
         item["getDateReceived"] = self.ulocalized_time(received, long_format=1)
         item["getDateSampled"] = self.ulocalized_time(sampled, long_format=1)
         return item


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**Requires https://github.com/senaite/senaite.app.listing/pull/96**

This Pull Request makes it possible to sort sample listings from inbound and outbound shipments

## Current behavior before PR

Cannot sort samples listings from inbound and outbound shipments

## Desired behavior after PR is merged

Can sort samples listings from inbound and outbound shipments

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html