### PR TITLE
Add configuration parameter for the chunk size on inbuond sample reception

### DIFF
--- a/src/senaite/referral/browser/controlpanel.py
+++ b/src/senaite/referral/browser/controlpanel.py
@@ -64,6 +64,23 @@ class IReferralControlPanel(Interface):
         required=False,
     )
 
+    chunk_size_receive_inbound_sample = schema.Int(
+        title=_(
+            u"label_chunk_size_receive_inbound_sample",
+            u"Maximum number of inbound samples to receive in a single task"
+        ),
+        description=_(
+            u"description_chunk_size_receive_inbound_sample",
+            u"If the number of inbound samples to receive is above this "
+            u"value, the queue will split the job in as many tasks as "
+            u"required. If the value is 0 or senaite queue is not installed, "
+            u"the system won't process the inbound samples asynchronously and "
+            u"all them will be held in a single request"
+        ),
+        default=5,
+        required=0,
+    )
+
 
 class ReferralControlPanelForm(RegistryEditForm):
     schema = IReferralControlPanel

--- a/src/senaite/referral/profiles/default/metadata.xml
+++ b/src/senaite/referral/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>1003</version>
+  <version>1004</version>
 
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>

--- a/src/senaite/referral/upgrade/v01_00_000.py
+++ b/src/senaite/referral/upgrade/v01_00_000.py
@@ -186,3 +186,11 @@ def fix_inbound_samples_received(tool):
         shipment._p_deactivate()
 
     logger.info("Fix inbound samples received but without sample [DONE]")
+
+
+def setup_chunk_size_receive_inbound_sample(tool):
+    logger.info("Setup chunk size for inbound sample reception ...")
+    portal = tool.aq_inner.aq_parent
+    setup = portal.portal_setup
+    setup.runImportStepFromProfile(profile, "plone.app.registry")
+    logger.info("Setup chunk size for inbound sample reception [DONE]")

--- a/src/senaite/referral/upgrade/v01_00_000.zcml
+++ b/src/senaite/referral/upgrade/v01_00_000.zcml
@@ -3,6 +3,15 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     i18n_domain="senaite.referral">
 
+  <!-- Setup chunk size for inbound sample reception -->
+  <genericsetup:upgradeStep
+      title="SENAITE.REFERRAL 1.0.0: Setup chunk size for inbound sample reception"
+      description="Fix inbound samples received without sample"
+      source="1003"
+      destination="1004"
+      handler="senaite.referral.upgrade.v01_00_000.setup_chunk_size_receive_inbound_sample"
+      profile="senaite.referral:default"/>
+
   <!-- Fix inbound samples received without sample -->
   <genericsetup:upgradeStep
       title="SENAITE.REFERRAL 1.0.0: Fix inbound samples received without sample"

--- a/src/senaite/referral/utils.py
+++ b/src/senaite/referral/utils.py
@@ -23,6 +23,7 @@ import copy
 import json
 from datetime import datetime
 
+from plone.api.exc import InvalidParameterError
 from senaite.referral import messageFactory as _
 from senaite.referral import PRODUCT_NAME
 from six import string_types
@@ -188,6 +189,17 @@ def is_manual_inbound_shipment_permitted():
     """
     key = "{}.manual_inbound_permitted".format(PRODUCT_NAME)
     return api.get_registry_record(key, default=False)
+
+
+def get_chunk_size_for(action):
+    """Returns the chunk_size for the given action
+    """
+    try:
+        key = "{}.chunk_size_{}".format(PRODUCT_NAME, action)
+        chunk_size = api.get_registry_record(key, default=5)
+    except InvalidParameterError:
+        chunk_size = 5
+    return api.to_int(chunk_size, 5)
 
 
 def to_uids(value):


### PR DESCRIPTION
This Pull Request adds a configuration parameter in the registry to allow the user to set the predefined size of chunks for the reception of inbound samples by the queue. It defaults to 5