### PR TITLE
Display full name of referring lab and reference lab in the manifest

### DIFF
--- a/src/senaite/referral/browser/templates/shipment_manifest_template.pt
+++ b/src/senaite/referral/browser/templates/shipment_manifest_template.pt
@@ -110,9 +110,11 @@
               <td class="align-middle text-left">
                 <h2 i18n:translate="">Receiver</h2>
                 <address class="address">
-                  <div class="lab-title font-weight-bold" tal:content="reflab/code|nothing"></div>
+                  <div class="lab-title font-weight-bold">
+                    <span  tal:content="reflab/Title|nothing"/>&nbsp;
+                    (<span tal:content="reflab/code|nothing"/>)
+                  </div>
                 </address>
-
                 <h2 i18n:translate="">Courier</h2>
                 <div class="courier-info" tal:content="python:view.request.form.get('courier')"></div>
               </td>

--- a/src/senaite/referral/browser/templates/shipment_manifest_template.pt
+++ b/src/senaite/referral/browser/templates/shipment_manifest_template.pt
@@ -83,7 +83,7 @@
               <td class="align-middle text-left">
                 <h2 i18n:translate="">Shipper</h2>
                 <address class="address">
-                  <div class="lab-title font-weight-bold" tal:content="laboratory/title|nothing"></div>
+                  <div class="lab-title font-weight-bold" tal:content="laboratory/Name|nothing"></div>
                   <div class="lab-supervisor"
                        tal:condition="laboratory/Supervisor"
                        tal:content="laboratory/Supervisor/Fullname|nothing"></div>


### PR DESCRIPTION
This Pull Request ensures that the full names of both the referring and reference laboratories are displayed in the shipment manifest

![Captura de 2023-02-02 19-37-17](https://user-images.githubusercontent.com/832627/216419123-b4bbabbc-9e05-405d-a78c-cfb7e6532503.png)
