### PR TITLE
Remove explicit assignment of external (referring) lab for Inbound Shipments

### DIFF
--- a/src/senaite/referral/catalog/indexer/inboundshipment.py
+++ b/src/senaite/referral/catalog/indexer/inboundshipment.py
@@ -29,7 +29,8 @@ from bika.lims import api
 def laboratory_uid(instance):
     """Returns the UID of the lab referring the inbound sample shipment
     """
-    return instance.getRawReferringLaboratory()
+    lab = instance.getReferringLaboratory()
+    return api.get_uid(lab)
 
 
 @indexer(IInboundSampleShipment, IShipmentCatalog)

--- a/src/senaite/referral/catalog/indexer/outboundshipment.py
+++ b/src/senaite/referral/catalog/indexer/outboundshipment.py
@@ -29,8 +29,8 @@ from bika.lims import api
 def laboratory_uid(instance):
     """Returns the UID of the destination laboratory for this shipment
     """
-    referring_laboratory = instance.getReferenceLaboratory()
-    return api.get_uid(referring_laboratory)
+    reference_lab = instance.getReferenceLaboratory()
+    return api.get_uid(reference_lab)
 
 
 @indexer(IOutboundSampleShipment, IShipmentCatalog)

--- a/src/senaite/referral/configure.zcml
+++ b/src/senaite/referral/configure.zcml
@@ -28,9 +28,6 @@
 
   <!-- Vocabularies -->
   <utility
-      component="senaite.referral.vocabularies.ReferringLaboratoriesVocabularyFactory"
-      name="senaite.referral.vocabularies.referringlaboratories" />
-  <utility
       component="senaite.referral.vocabularies.ReferenceLaboratoriesVocabularyFactory"
       name="senaite.referral.vocabularies.referencelaboratories" />
   <utility

--- a/src/senaite/referral/content/inboundsampleshipment.py
+++ b/src/senaite/referral/content/inboundsampleshipment.py
@@ -31,7 +31,6 @@ from senaite.referral.content import get_uids_field_value
 from senaite.referral.content import set_datetime_value
 from senaite.referral.content import set_string_value
 from senaite.referral.content import set_uids_field_value
-from senaite.referral.interfaces import IExternalLaboratory
 from senaite.referral.interfaces import IInboundSample
 from senaite.referral.interfaces import IInboundSampleShipment
 from senaite.referral.utils import get_action_date
@@ -41,21 +40,6 @@ from zope.interface import invariant
 
 from bika.lims import api
 from bika.lims.interfaces import IClient
-
-
-def check_referring_laboratory(thing):
-    """Checks if the referring laboratory passed in is valid
-    """
-    obj = api.get_object(thing, default=None)
-    if not IExternalLaboratory.providedBy(obj):
-        raise ValueError("Type is not supported: {}".format(repr(obj)))
-
-    if not obj.getReferring():
-        # The external laboratory must be enabled as referring laboratory
-        raise ValueError("The external laboratory cannot act as a "
-                         "referring laboratory")
-
-    return True
 
 
 def check_referring_client(thing):
@@ -93,14 +77,6 @@ class IInboundSampleShipmentSchema(model.Schema):
         required=True,
     )
 
-    referring_laboratory = schema.Choice(
-        title=_(u"label_inboundsampleshipment_referring_laboratory",
-                default=u"Referring laboratory"),
-        description=_(u"The referring laboratory the samples come from"),
-        vocabulary="senaite.referral.vocabularies.referringlaboratories",
-        required=True,
-    )
-
     referring_client = schema.Choice(
         title=_(u"label_inboundsampleshipment_referring_client",
                 default=u"Referring client"),
@@ -127,15 +103,6 @@ class IInboundSampleShipmentSchema(model.Schema):
         ),
         required=True,
     )
-
-    @invariant
-    def validate_referring_laboratory(data):
-        """Checks if the value for field referring_laboratory is valid
-        """
-        val = data.referring_laboratory
-        if not val:
-            return
-        check_referring_laboratory(val)
 
     @invariant
     def validate_referring_client(data):
@@ -237,18 +204,6 @@ class InboundSampleShipment(Container):
         """Returns the client the samples come from
         """
         return api.get_parent(self)
-
-    @security.protected(permissions.View)
-    def getRawReferringLaboratory(self):
-        lab = self.getReferringLaboratory()
-        return api.get_uid(lab)
-
-    @security.protected(permissions.ModifyPortalContent)
-    def setReferringLaboratory(self, value):
-        """Sets the client the samples come from
-        """
-        set_uids_field_value(self, "referring_laboratory", value,
-                             validator=check_referring_laboratory)
 
     @security.protected(permissions.View)
     def getReferringClient(self):

--- a/src/senaite/referral/content/inboundsampleshipment.py
+++ b/src/senaite/referral/content/inboundsampleshipment.py
@@ -236,15 +236,12 @@ class InboundSampleShipment(Container):
     def getReferringLaboratory(self):
         """Returns the client the samples come from
         """
-        value = self.getRawReferringLaboratory()
-        return api.get_object(value, default=None)
+        return api.get_parent(self)
 
     @security.protected(permissions.View)
     def getRawReferringLaboratory(self):
-        value = get_uids_field_value(self, "referring_laboratory")
-        if not value:
-            return None
-        return value[0]
+        lab = self.getReferringLaboratory()
+        return api.get_uid(lab)
 
     @security.protected(permissions.ModifyPortalContent)
     def setReferringLaboratory(self, value):

--- a/src/senaite/referral/vocabularies.py
+++ b/src/senaite/referral/vocabularies.py
@@ -46,29 +46,6 @@ def to_simple_vocabulary(query, catalog_id):
 
 
 @implementer(IVocabularyFactory)
-class ReferringLaboratoriesVocabulary(object):
-    """Returns a simple vocabulary made of ExternalLaboratories that can send
-    us samples becasue they have the setting "Referring Laboratory" enabled
-    """
-
-    def __call__(self, context):
-        query = {
-            "portal_type": "ExternalLaboratory",
-            "is_active": True,
-            "sort_on": "sortable_title",
-            "sort_order": "ascending",
-        }
-        items = []
-        for brain in api.search(query, "portal_catalog"):
-            obj = api.get_object(brain)
-            if obj.getReferring():
-                # Only those external labs that can act as referring labs
-                items.append(to_simple_term(obj))
-
-        return SimpleVocabulary(items)
-
-
-@implementer(IVocabularyFactory)
 class ReferenceLaboratoriesVocabulary(object):
     """Returns a simple vocabulary made of ExternalLaboratories to which we can
     send samples because they have the setting "Reference Laboratory" enabled
@@ -108,6 +85,5 @@ class ClientsVocabulary(object):
         return SimpleVocabulary(items)
 
 
-ReferringLaboratoriesVocabularyFactory = ReferringLaboratoriesVocabulary()
 ReferenceLaboratoriesVocabularyFactory = ReferenceLaboratoriesVocabulary()
 ClientsVocabularyFactory = ClientsVocabulary()


### PR DESCRIPTION
This Pull Request removes the explicit assignment of external laboratory for inbound sample shipments. This is not necessary because objects from type `InboundSampleShipment` are always created as contents of `ExternalLaboratory` objects. Therefore, the external laboratory (referring lab) is always the parent and there is no need to keep the reference twice.