### PR TITLE
Added status "Rejected at reference"

### DIFF
--- a/src/senaite/referral/adapters/guards/sample.py
+++ b/src/senaite/referral/adapters/guards/sample.py
@@ -45,3 +45,15 @@ class SampleGuardAdapter(BaseGuardAdapter):
         analyses = self.context.getAnalyses(full_objects=True)
         valid = map(lambda an: api.get_review_status(an) in allowed, analyses)
         return all(valid)
+
+    def guard_reject_at_reference(self):
+        """Returns true if the sample can be transitioned to rejected at
+        reference sample
+        """
+        # Do not allow to reject unless a POST from remote lab
+        request = api.get_request()
+        lab_code = request.get("lab_code")
+        if not lab_code:
+            return False
+
+        return True

--- a/src/senaite/referral/jsonapi/consumer.py
+++ b/src/senaite/referral/jsonapi/consumer.py
@@ -118,6 +118,9 @@ class ReferralConsumer(BaseConsumer):
             raise ValueError("Laboratory is not active: {}".format(
                 self.lab_code))
 
+        # We need to bypass the guard's check for current context!
+        api.get_request().set("lab_code", self.lab_code)
+
         # Iterate through items and process them
         for item in self.items:
 
@@ -140,7 +143,7 @@ class ReferralConsumer(BaseConsumer):
         rejection_reasons = self.get_value(item, "RejectionReasons")
         obj = self.get_object_for(item)
         obj.setRejectionReasons(rejection_reasons)
-        self.do_action(obj, "reject")
+        self.do_action(obj, "reject_at_reference")
 
     def do_action(self, item_or_object, action):
         """Performs an action against the given object

--- a/src/senaite/referral/jsonapi/outboundsample.py
+++ b/src/senaite/referral/jsonapi/outboundsample.py
@@ -129,7 +129,18 @@ class OutboundSampleConsumer(object):
         brains = api.search(query, CATALOG_ANALYSIS_REQUEST_LISTING)
         if not brains:
             raise ValueError("Sample not found: {}".format(sample_id))
-        return api.get_object(brains[0])
+
+        if len(brains) > 0:
+            raise ValueError("More than one sample: {}".format(sample_id))
+
+        # Get the sample object
+        sample = api.get_object(brains[0])
+
+        # Do not allow to modify the sample if not referred
+        if api.get_review_status(sample) != "shipped":
+            raise ValueError("Sample is not referred: {}".format(sample_id))
+
+        return sample
 
     def update_analysis(self, analysis, record):
         if not analysis:

--- a/src/senaite/referral/profiles/default/metadata.xml
+++ b/src/senaite/referral/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>1004</version>
+  <version>1005</version>
 
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>

--- a/src/senaite/referral/setuphandlers.py
+++ b/src/senaite/referral/setuphandlers.py
@@ -51,9 +51,16 @@ WORKFLOWS_TO_UPDATE = {
             "shipped": {
                 "title": "Referred",
                 "description": "Sample is referred to reference laboratory",
-                "transitions": ("verify",),
+                "transitions": ("verify", "recall_from_shipment"),
                 # Sample is read-only
                 "permissions_copy_from":  "invalid",
+            },
+            "rejected_at_reference": {
+                "title": "Rejected at reference lab",
+                "description": "Sample rejected at reference laboratory",
+                "transitions": ("recall_from_shipment",),
+                # Sample is read-only
+                "permissions_copy_from": "invalid",
             }
         },
         "transitions": {
@@ -65,6 +72,16 @@ WORKFLOWS_TO_UPDATE = {
                     "guard_permissions": "",
                     "guard_roles": "",
                     "guard_expr": "python:here.guard_handler('ship')",
+                }
+            },
+            "recall_from_shipment": {
+                "title": "Reinstate",
+                "new_state": "",
+                "action": "Recall from shipment",
+                "guard": {
+                    "guard_permissions": "",
+                    "guard_roles": "",
+                    "guard_expr": "python:here.guard_handler('recall_from_shipment')",
                 }
             },
         }

--- a/src/senaite/referral/setuphandlers.py
+++ b/src/senaite/referral/setuphandlers.py
@@ -89,7 +89,7 @@ WORKFLOWS_TO_UPDATE = {
                 }
             },
             "recall_from_shipment": {
-                "title": "Reinstate",
+                "title": "Recall from shipment",
                 "new_state": "",
                 "action": "Recall from shipment",
                 "guard": {

--- a/src/senaite/referral/setuphandlers.py
+++ b/src/senaite/referral/setuphandlers.py
@@ -51,7 +51,11 @@ WORKFLOWS_TO_UPDATE = {
             "shipped": {
                 "title": "Referred",
                 "description": "Sample is referred to reference laboratory",
-                "transitions": ("verify", "recall_from_shipment"),
+                "transitions": (
+                    "verify",
+                    "reject_at_reference",
+                    "recall_from_shipment"
+                ),
                 # Sample is read-only
                 "permissions_copy_from":  "invalid",
             },
@@ -72,6 +76,16 @@ WORKFLOWS_TO_UPDATE = {
                     "guard_permissions": "",
                     "guard_roles": "",
                     "guard_expr": "python:here.guard_handler('ship')",
+                }
+            },
+            "reject_at_reference": {
+                "title": "Reject sample (at reference lab)",
+                "new_state": "rejected_at_reference",
+                "action": "Reject at reference lab",
+                "guard": {
+                    "guard_permissions": "",
+                    "guard_roles": "",
+                    "guard_expr": "python:here.guard_handler('reject_at_reference')",
                 }
             },
             "recall_from_shipment": {

--- a/src/senaite/referral/upgrade/v01_00_000.py
+++ b/src/senaite/referral/upgrade/v01_00_000.py
@@ -25,6 +25,7 @@ from senaite.referral.catalog import INBOUND_SAMPLE_CATALOG
 from senaite.referral.catalog import SHIPMENT_CATALOG
 from senaite.referral.config import PRODUCT_NAME as product
 from senaite.referral.setuphandlers import setup_catalogs
+from senaite.referral.setuphandlers import setup_workflows
 
 from bika.lims import api
 from bika.lims.utils import changeWorkflowState
@@ -194,3 +195,13 @@ def setup_chunk_size_receive_inbound_sample(tool):
     setup = portal.portal_setup
     setup.runImportStepFromProfile(profile, "plone.app.registry")
     logger.info("Setup chunk size for inbound sample reception [DONE]")
+
+
+def setup_recall_from_shipment(tool):
+    logger.info("Setup transition 'recall_from_shipment' ...")
+    portal = tool.aq_inner.aq_parent
+
+    # Setup workflows
+    setup_workflows(portal)
+
+    logger.info("Setup transition 'recall_from_shipment' [DONE]")

--- a/src/senaite/referral/upgrade/v01_00_000.zcml
+++ b/src/senaite/referral/upgrade/v01_00_000.zcml
@@ -5,11 +5,20 @@
 
   <!-- Setup chunk size for inbound sample reception -->
   <genericsetup:upgradeStep
+      title="SENAITE.REFERRAL 1.0.0: Allow to recall a sample from shipment"
+      description="Added the transition 'recall_from_shipment'"
+      source="1004"
+      destination="1005"
+      handler=".v01_00_000.setup_recall_from_shipment"
+      profile="senaite.referral:default"/>
+
+  <!-- Setup chunk size for inbound sample reception -->
+  <genericsetup:upgradeStep
       title="SENAITE.REFERRAL 1.0.0: Setup chunk size for inbound sample reception"
       description="Fix inbound samples received without sample"
       source="1003"
       destination="1004"
-      handler="senaite.referral.upgrade.v01_00_000.setup_chunk_size_receive_inbound_sample"
+      handler=".v01_00_000.setup_chunk_size_receive_inbound_sample"
       profile="senaite.referral:default"/>
 
   <!-- Fix inbound samples received without sample -->
@@ -18,7 +27,7 @@
       description="Fix inbound samples received without sample"
       source="1002"
       destination="1003"
-      handler="senaite.referral.upgrade.v01_00_000.fix_inbound_samples_received"
+      handler=".v01_00_000.fix_inbound_samples_received"
       profile="senaite.referral:default"/>
 
   <!-- Decouple reception of shipment from reception of inbound samples -->
@@ -27,7 +36,7 @@
       description="Decouple reception of shipment from reception of inbound samples"
       source="1001"
       destination="1002"
-      handler="senaite.referral.upgrade.v01_00_000.decouple_receive_shipment"
+      handler=".v01_00_000.decouple_receive_shipment"
       profile="senaite.referral:default"/>
 
   <!-- New catalog for shipment objects
@@ -37,7 +46,7 @@
       description="New catalog for shipment objects"
       source="1.0.0"
       destination="1001"
-      handler="senaite.referral.upgrade.v01_00_000.setup_new_catalog_shipments"
+      handler=".v01_00_000.setup_new_catalog_shipments"
       profile="senaite.referral:default"/>
 
 </configure>

--- a/src/senaite/referral/workflow/analysisrequest.py
+++ b/src/senaite/referral/workflow/analysisrequest.py
@@ -20,6 +20,7 @@
 
 from senaite.referral import check_installed
 from senaite.referral.remotelab import get_remote_connection
+from senaite.referral.workflow import restore_referred_sample
 from senaite.referral.workflow import ship_sample
 
 from bika.lims.workflow import doActionFor
@@ -43,6 +44,9 @@ def AfterTransitionEventHandler(sample, event): # noqa lowercase
 
     if event.transition.id == "reject":
         after_reject(sample)
+
+    if event.transition.id == "recall_from_shipment":
+        restore_referred_sample(sample)
 
 
 def after_no_sampling_workflow(sample):


### PR DESCRIPTION
This Pull Request adds the status "Rejected at reference" as well as two additional transitions: "Recall from shipment" and "Reject at reference". When any of these two actions is triggered, the sample (at the referring laboratory) is transitioned to the status "Rejected at reference".

Samples with status "Rejected at reference" are displayed in samples listing, under "Rejected" and/or "Referred" filters.

- The transition "Recall from shipment" can only be done by the referring laboratory
- The transition "Rejected at reference" cannot be done manually, but via POST from the reference laboratory only
