### PR TITLE
Auto-transition samples at referring lab on rejection of an inbound shipment

### DIFF
--- a/src/senaite/referral/adapters/guards/inboundshipment.py
+++ b/src/senaite/referral/adapters/guards/inboundshipment.py
@@ -55,3 +55,12 @@ class InboundShipmentGuardAdapter(BaseGuardAdapter):
             if is_transition_allowed(inbound_sample, action_id):
                 return False
         return True
+
+    def guard_reject_inbound_shipment(self):
+        """Returns true if the inbound shipment does not have any sample or
+        none of them were received
+        """
+        for inbound_sample in self.context.getInboundSamples():
+            if inbound_sample.getRawSample():
+                return False
+        return True

--- a/src/senaite/referral/jsonapi/consumer.py
+++ b/src/senaite/referral/jsonapi/consumer.py
@@ -145,6 +145,15 @@ class ReferralConsumer(BaseConsumer):
         obj.setRejectionReasons(rejection_reasons)
         self.do_action(obj, "reject_at_reference")
 
+    def do_inboundsampleshipment_reject(self, item):
+        """Rejects the counterpart outbound shipment at local instance, and
+        transitions its samples to 'Rejected at reference' as well
+        """
+        shipment = self.get_object_for(item)
+        self.do_action(shipment, "reject_outbound_shipment")
+        for sample in shipment.getSamples():
+            self.do_action(sample, "reject_at_reference")
+
     def do_action(self, item_or_object, action):
         """Performs an action against the given object
         """

--- a/src/senaite/referral/workflow/inboundshipment/events.py
+++ b/src/senaite/referral/workflow/inboundshipment/events.py
@@ -52,8 +52,8 @@ def after_receive_inbound_shipment(shipment):
 
 def after_reject_inbound_shipment(shipment):
     """Event fired after transition "reject_inbound_shipment" for an Inbound
-    Sample Shipment is triggered. All Samples from the shipment, even if not
-    yet received, are rejected too
+    Sample Shipment is triggered. All inbound samples from the shipment are
+    rejected as well
     """
     # Reject all InboundSample objects (not-yet-received)
     for inbound_sample in shipment.getInboundSamples():
@@ -66,4 +66,8 @@ def after_reject_inbound_shipment(shipment):
         return
 
     # Mark the outbound shipment counterpart as rejected
-    remote_lab.do_action(shipment, "reject_outbound_shipment")
+    # We do "reject" (instead of "reject_outbound_shipment") because "reject"
+    # action is trapped by the referring lab consumer. The consumer, besides
+    # triggering the "reject_outbound_shipment" workflow action, it also
+    # transitions its samples to "rejected_at_reference" status.
+    remote_lab.do_action(shipment, "reject")

--- a/src/senaite/referral/workflow/outboundshipment/events.py
+++ b/src/senaite/referral/workflow/outboundshipment/events.py
@@ -32,7 +32,7 @@ def after_dispatch_outbound_shipment(shipment):
     if not remote_lab:
         return
 
-    # Create an inbound shipment counterpart in the receiving laboratory
+    # Create an inbound shipment counterpart at the reference laboratory
     remote_lab.create_inbound_shipment(shipment)
 
 
@@ -46,7 +46,7 @@ def after_reject_outbound_shipment(shipment):
     if not remote_lab:
         return
 
-    # Reject the inbound shipment counterpart in the receiving laboratory
+    # Reject the inbound shipment counterpart at the reference laboratory
     remote_lab.do_action(shipment, "reject_inbound_shipment")
 
 


### PR DESCRIPTION
This Pull Request does the following:

- An inbound shipment can only be rejected if none of its samples were received
- When an inbound shipment is rejected, counterpart shipment at reference laboratory is transitioned to "Rejected", and its samples are all automatically transitioned to "Rejected at reference lab"
