### PR TITLE
Fix inbound samples in received status but without sample type counterpart

### DIFF
--- a/src/senaite/referral/adapters/guards/inboundsample.py
+++ b/src/senaite/referral/adapters/guards/inboundsample.py
@@ -19,6 +19,7 @@
 # Some rights reserved, see README and LICENSE.
 
 from senaite.referral.adapters.guards import BaseGuardAdapter
+from senaite.referral.utils import search_sample_type
 from zope.interface import implementer
 
 from bika.lims.interfaces import IGuardAdapter
@@ -34,4 +35,10 @@ class InboundSampleGuardAdapter(BaseGuardAdapter):
         """
         if self.context.getRawSample():
             return False
+
+        # check if a counterpart sample type exists
+        term = self.context.getSampleType()
+        if not search_sample_type(term):
+            return False
+
         return True

--- a/src/senaite/referral/adapters/guards/inboundshipment.py
+++ b/src/senaite/referral/adapters/guards/inboundshipment.py
@@ -18,11 +18,11 @@
 # Copyright 2021-2022 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from senaite.referral.adapters.guards import BaseGuardAdapter
-from zope.interface import implementer
-
+from bika.lims import api
 from bika.lims.interfaces import IGuardAdapter
 from bika.lims.workflow import isTransitionAllowed as is_transition_allowed
+from senaite.referral.adapters.guards import BaseGuardAdapter
+from zope.interface import implementer
 
 
 @implementer(IGuardAdapter)
@@ -48,12 +48,12 @@ class InboundShipmentGuardAdapter(BaseGuardAdapter):
         if not samples:
             return False
 
-        action_id = "receive_inbound_sample"
         for inbound_sample in samples:
             if inbound_sample.getRawSample():
                 continue
-            if is_transition_allowed(inbound_sample, action_id):
+            if api.get_review_status(inbound_sample) == "due":
                 return False
+
         return True
 
     def guard_reject_inbound_shipment(self):

--- a/src/senaite/referral/browser/inbound/samples.py
+++ b/src/senaite/referral/browser/inbound/samples.py
@@ -24,6 +24,7 @@ from bika.lims import api
 from bika.lims import PRIORITIES
 from bika.lims.utils import get_image
 from bika.lims.utils import get_link_for
+from bika.lims.utils import render_html_attributes
 from plone.memoize import view
 from senaite.app.listing import ListingView
 from senaite.core.api import dtime
@@ -218,8 +219,8 @@ class SamplesListingView(ListingView):
             sample_type = obj.getSampleType()
             if not self.get_sample_type_uid(sample_type):
                 msg = _("No sample type found for '{}'".format(sample_type))
-                img = get_image("warning.png", title=msg)
-                item["replace"]["sample_type"] = "".join([img, sample_type])
+                span = self.get_danger_html(sample_type, msg)
+                item["replace"]["sample_type"] = span
 
             item.update({
                 "getReferringID": obj.getReferringID(),
@@ -241,6 +242,13 @@ class SamplesListingView(ListingView):
             item["replace"]["priority"] = priority
 
         return item
+
+    def get_danger_html(self, text, title):
+        """Returns an html with the text and title provided
+        """
+        css = "fas fa-exclamation-circle pr-1"
+        attrs = render_html_attributes(title=title, css_class=css)
+        return "<span class='text-danger'><i {}></i>{}".format(attrs, text)
 
     def get_state_title(self, obj):
         """Translates the review state to the current set language

--- a/src/senaite/referral/profiles/default/metadata.xml
+++ b/src/senaite/referral/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>2001</version>
+  <version>2002</version>
 
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>

--- a/src/senaite/referral/upgrade/v02_00_000.zcml
+++ b/src/senaite/referral/upgrade/v02_00_000.zcml
@@ -4,6 +4,16 @@
     i18n_domain="senaite.referral">
 
   <genericsetup:upgradeStep
+      title="SENAITE.REFERRAL 2.0.0: Fix received inbound samples without type"
+      description="
+        Walks through all inbound samples without sample counterpart that
+        belong to shipments in due status and transitions them to due status"
+      source="2001"
+      destination="2002"
+      handler=".v02_00_000.fix_received_samples_wo_type"
+      profile="senaite.referral:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.REFERRAL 2.0.0: Setup async transitions"
       description="Setup default ajax transitions"
       source="2000"

--- a/src/senaite/referral/utils.py
+++ b/src/senaite/referral/utils.py
@@ -324,3 +324,14 @@ def get_services_mapping():
         services[keyword] = uid
         services[uid] = uid
     return services
+
+
+def search_sample_type(term, full_object=False):
+    """Returns the Sample Type that matches with the given term, if any.
+    Returns None otherwise
+    """
+    sample_types = get_sample_types_mapping()
+    uid = sample_types.get(term)
+    if uid and full_object:
+        return api.get_object_by_uid(uid)
+    return uid

--- a/src/senaite/referral/workflow/inboundsample/events.py
+++ b/src/senaite/referral/workflow/inboundsample/events.py
@@ -18,12 +18,11 @@
 # Copyright 2021-2022 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
-from senaite.referral.utils import get_sample_types_mapping
-from senaite.referral.utils import get_services_mapping
-
 from bika.lims import api
 from bika.lims.utils.analysisrequest import create_analysisrequest
 from bika.lims.workflow import doActionFor
+from senaite.referral.utils import get_sample_types_mapping
+from senaite.referral.utils import get_services_mapping
 
 
 def after_receive_inbound_sample(inbound_sample):
@@ -79,6 +78,8 @@ def create_sample(inbound_sample):
     # Create the sample object
     sample_type = inbound_sample.getSampleType()
     sample_type_uid = sample_types.get(sample_type)
+    if not sample_type_uid:
+        raise ValueError("No sample type found for '{}'".format(sample_type))
 
     keywords = inbound_sample.getAnalyses() or []
     services_uids = map(lambda key: services.get(key), keywords)


### PR DESCRIPTION
This Pull Request does the following:

- displays an alert in inbound sample listings when there is no match with any existing sample type
- prevents inbound samples to be transitioned to received status when there is no match with any existing sample type
- raises a ValueError when creating a sample counterpart if there is no match with any existing sample type

It also adds an upgrade step that walks through all inbound samples without sample counterpart that belong to shipments in due status and transitions them to due status

![Captura de 2024-02-01 14-25-02](https://github.com/senaite/senaite.referral/assets/832627/5926d4a8-89be-4146-9ea1-5fe5427d7d66)
