### PR TITLE
Notify back invalidated samples at reference lab

### DIFF
--- a/src/senaite/referral/adapters/guards/sample.py
+++ b/src/senaite/referral/adapters/guards/sample.py
@@ -57,3 +57,14 @@ class SampleGuardAdapter(BaseGuardAdapter):
             return False
 
         return True
+
+    def guard_invalidate_at_reference(self):
+        """Returns true if current request contains a POST with the
+        'invalidate_at_reference' action to ensure this transition is not
+        performed manually,
+        """
+        request = api.get_request()
+        lab_code = request.get("lab_code")
+        if not lab_code:
+            return False
+        return True

--- a/src/senaite/referral/adapters/listing/samples.py
+++ b/src/senaite/referral/adapters/listing/samples.py
@@ -142,33 +142,6 @@ class SamplesListingViewAdapter(object):
                 statuses.append("rejected_at_reference")
                 rv["contentFilter"]["review_state"] = list(set(statuses))
 
-        # New review_state "invalidated_at_reference"
-        rejected_at_reference = {
-            "id": "invalidated_at_reference",
-            "title": _("Invalidated at reference"),
-            "contentFilter": {
-                "review_state": ("invalidated_at_reference", ),
-                "sort_on": "created",
-                "sort_order": "descending"},
-            "transitions": [],
-            "custom_transitions": list(default_actions),
-            "columns": list(default_columns),
-        }
-        listing_utils.add_review_state(
-            listing=self.listing,
-            review_state=rejected_at_reference,
-            after="rejected_at_reference")
-
-        # Update "invalidated" review state to include those that have been
-        # rejected by the reference laboratory
-        for rv in self.listing.review_states:
-            if rv.get("id") == "invalid":
-                statuses = rv["contentFilter"].get("review_state")
-                if not isinstance(statuses, (list, tuple)):
-                    statuses = [statuses]
-                statuses.append("invalidated_at_reference")
-                rv["contentFilter"]["review_state"] = list(set(statuses))
-
     def add_columns(self):
         """Adds referral-specific columns in the listing
         """

--- a/src/senaite/referral/adapters/listing/samples.py
+++ b/src/senaite/referral/adapters/listing/samples.py
@@ -142,6 +142,33 @@ class SamplesListingViewAdapter(object):
                 statuses.append("rejected_at_reference")
                 rv["contentFilter"]["review_state"] = list(set(statuses))
 
+        # New review_state "invalidated_at_reference"
+        rejected_at_reference = {
+            "id": "invalidated_at_reference",
+            "title": _("Invalidated at reference"),
+            "contentFilter": {
+                "review_state": ("invalidated_at_reference", ),
+                "sort_on": "created",
+                "sort_order": "descending"},
+            "transitions": [],
+            "custom_transitions": list(default_actions),
+            "columns": list(default_columns),
+        }
+        listing_utils.add_review_state(
+            listing=self.listing,
+            review_state=rejected_at_reference,
+            after="rejected_at_reference")
+
+        # Update "invalidated" review state to include those that have been
+        # rejected by the reference laboratory
+        for rv in self.listing.review_states:
+            if rv.get("id") == "invalid":
+                statuses = rv["contentFilter"].get("review_state")
+                if not isinstance(statuses, (list, tuple)):
+                    statuses = [statuses]
+                statuses.append("invalidated_at_reference")
+                rv["contentFilter"]["review_state"] = list(set(statuses))
+
     def add_columns(self):
         """Adds referral-specific columns in the listing
         """

--- a/src/senaite/referral/jsonapi/consumer.py
+++ b/src/senaite/referral/jsonapi/consumer.py
@@ -25,11 +25,11 @@ from plone.memoize.instance import memoize
 from senaite.jsonapi.interfaces import IPushConsumer
 from senaite.referral import utils
 from senaite.referral.catalog import SHIPMENT_CATALOG
+from senaite.referral.workflow import change_workflow_state
 from zope.interface import implementer
 
 from bika.lims import api
 from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
-from bika.lims.utils import changeWorkflowState
 from bika.lims.workflow import doActionFor
 from bika.lims.workflow import isTransitionAllowed
 
@@ -178,6 +178,7 @@ class ReferralConsumer(BaseConsumer):
             return
 
         # Do force the transition
+        # TODO Remove force the transition
         workflows = api.get_workflows_for(obj)
         wf_tool = api.get_tool("portal_workflow")
         for wf_id in workflows:
@@ -187,7 +188,7 @@ class ReferralConsumer(BaseConsumer):
             transition = workflow.transitions[action]
             status = transition.new_state_id
             kwargs = {"action": action}
-            changeWorkflowState(obj, wf_id, status, **kwargs)
+            change_workflow_state(obj, wf_id, status, **kwargs)
 
     def get_counterpart_type(self, portal_type):
         """Returns the counterpart type for the portal type passed in

--- a/src/senaite/referral/setuphandlers.py
+++ b/src/senaite/referral/setuphandlers.py
@@ -53,6 +53,7 @@ WORKFLOWS_TO_UPDATE = {
                 "description": "Sample is referred to reference laboratory",
                 "transitions": (
                     "verify",
+                    "invalidate_at_reference",
                     "reject_at_reference",
                     "recall_from_shipment"
                 ),
@@ -69,10 +70,8 @@ WORKFLOWS_TO_UPDATE = {
             "invalidated_at_reference": {
                 "title": "Invalidated at reference lab",
                 "description": "Sample invalidated at reference laboratory",
-                # This is an end-state
-                "transitions": (),
-                # Sample is read-only
-                "permissions_copy_from": "invalid",
+                "transitions": ("invalidate",),
+                "permissions_copy_from": "published",
             },
         },
         "transitions": {

--- a/src/senaite/referral/setuphandlers.py
+++ b/src/senaite/referral/setuphandlers.py
@@ -65,7 +65,15 @@ WORKFLOWS_TO_UPDATE = {
                 "transitions": ("recall_from_shipment",),
                 # Sample is read-only
                 "permissions_copy_from": "invalid",
-            }
+            },
+            "invalidated_at_reference": {
+                "title": "Invalidated at reference lab",
+                "description": "Sample invalidated at reference laboratory",
+                # This is an end-state
+                "transitions": (),
+                # Sample is read-only
+                "permissions_copy_from": "invalid",
+            },
         },
         "transitions": {
             "ship": {
@@ -86,6 +94,16 @@ WORKFLOWS_TO_UPDATE = {
                     "guard_permissions": "",
                     "guard_roles": "",
                     "guard_expr": "python:here.guard_handler('reject_at_reference')",
+                }
+            },
+            "invalidate_at_reference": {
+                "title": "Invalidate sample (at reference lab)",
+                "new_state": "invalidated_at_reference",
+                "action": "Invalidate at reference lab",
+                "guard": {
+                    "guard_permissions": "",
+                    "guard_roles": "",
+                    "guard_expr": "python:here.guard_handler('invalidate_at_reference')",
                 }
             },
             "recall_from_shipment": {

--- a/src/senaite/referral/upgrade/v01_00_000.py
+++ b/src/senaite/referral/upgrade/v01_00_000.py
@@ -205,3 +205,13 @@ def setup_recall_from_shipment(tool):
     setup_workflows(portal)
 
     logger.info("Setup transition 'recall_from_shipment' [DONE]")
+
+
+def setup_invalidate_at_reference(tool):
+    logger.info("Setup transition 'invalidate_at_reference' ...")
+    portal = tool.aq_inner.aq_parent
+
+    # Setup workflows
+    setup_workflows(portal)
+
+    logger.info("Setup transition 'invalidate_at_reference' [DONE]")

--- a/src/senaite/referral/upgrade/v01_00_000.zcml
+++ b/src/senaite/referral/upgrade/v01_00_000.zcml
@@ -3,6 +3,14 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     i18n_domain="senaite.referral">
 
+  <genericsetup:upgradeStep
+      title="SENAITE.REFERRAL 1.0.0: Invalidate at reference laboratory"
+      description="Added the transition 'invalidate_at_reference'"
+      source="1005"
+      destination="1006"
+      handler=".v01_00_000.setup_invalidate_at_reference"
+      profile="senaite.referral:default"/>
+
   <!-- Setup chunk size for inbound sample reception -->
   <genericsetup:upgradeStep
       title="SENAITE.REFERRAL 1.0.0: Allow to recall a sample from shipment"

--- a/src/senaite/referral/workflow/analysisrequest.py
+++ b/src/senaite/referral/workflow/analysisrequest.py
@@ -120,10 +120,11 @@ def get_remote_lab(shipment):
 
 
 def after_invalidate(sample):
-    """"Notify about the invalidation to reference and referring labs
+    """"Actions to do when invalidating a sample
     """
-    inbound_shipment = sample.getInboundShipment()
-    referring_lab = get_remote_lab(inbound_shipment)
-    if referring_lab:
-        # notify the referring laboratory about the invalidated sample
-        referring_lab.do_action(sample, "invalidate_at_reference")
+    shipment = sample.getInboundShipment()
+    referring = shipment.getReferringLaboratory()
+    referring = get_remote_connection(referring)
+    if referring:
+        # notify the referring laboratory
+        referring.do_action(sample, "invalidate_at_reference")

--- a/src/senaite/referral/workflow/analysisrequest.py
+++ b/src/senaite/referral/workflow/analysisrequest.py
@@ -22,10 +22,14 @@ from senaite.referral import check_installed
 from senaite.referral.interfaces import IInboundSampleShipment
 from senaite.referral.interfaces import IOutboundSampleShipment
 from senaite.referral.remotelab import get_remote_connection
+from senaite.referral.workflow import change_workflow_state
 from senaite.referral.workflow import restore_referred_sample
 from senaite.referral.workflow import ship_sample
 
 from bika.lims.workflow import doActionFor
+
+SAMPLE_WORKFLOW = "bika_ar_workflow"
+ANALYSIS_WORKFLOW = "bika_analysis_workflow"
 
 
 @check_installed(None)
@@ -49,6 +53,9 @@ def AfterTransitionEventHandler(sample, event): # noqa lowercase
 
     if event.transition.id == "invalidate":
         after_invalidate(sample)
+
+    if event.transition.id == "invalidate_at_reference":
+        after_invalidate_at_reference(sample)
 
     if event.transition.id == "recall_from_shipment":
         restore_referred_sample(sample)
@@ -123,8 +130,29 @@ def after_invalidate(sample):
     """"Actions to do when invalidating a sample
     """
     shipment = sample.getInboundShipment()
-    referring = shipment.getReferringLaboratory()
-    referring = get_remote_connection(referring)
+    referring = get_remote_lab(shipment)
     if referring:
         # notify the referring laboratory
         referring.do_action(sample, "invalidate_at_reference")
+
+
+def after_invalidate_at_reference(sample):
+    """Actions to do when a sample is invalidated at reference laboratory
+    """
+    retest = sample.getRetest()
+    if not retest:
+        # transition this sample to 'invalid' status
+        doActionFor(sample, "invalidate")
+        retest = sample.getRetest()
+    else:
+        # change workflow manually, but omit action so no after events
+        change_workflow_state(sample, SAMPLE_WORKFLOW, "invalid")
+
+    # manually transition the retest to 'referred' status
+    change_workflow_state(retest, SAMPLE_WORKFLOW, "shipped", action="ship")
+
+    # and its analyses as well
+    for analysis in retest.objectValues("Analysis"):
+        change_workflow_state(analysis, ANALYSIS_WORKFLOW,
+                              state_id="referred",
+                              action="refer")


### PR DESCRIPTION
This Pull Request makes the reference laboratory to notify back the referring laboratory on sample invalidation. 

The system proceeds as follows when a sample at the reference laboratory is invalidated:

- the referred sample at the referring is also invalidated
- the newly generated analysis request with R01, R02 etc is synchronized to the referring lab
- the results of the invalidated sample are sent to the corresponding sample at the referring lab
