### PR TITLE
Display a consistent status title in samples listing of inbound shipment

### DIFF
--- a/src/senaite/referral/browser/inbound/samples.py
+++ b/src/senaite/referral/browser/inbound/samples.py
@@ -24,6 +24,7 @@ from senaite.referral import messageFactory as _
 from senaite.referral.catalog import INBOUND_SAMPLE_CATALOG
 from senaite.referral.notifications import get_last_post
 from senaite.referral.utils import get_image_url
+from senaite.referral.utils import translate
 
 from bika.lims import api
 from bika.lims import PRIORITIES
@@ -201,7 +202,8 @@ class SamplesListingView(ListingView):
             item["replace"]["getSampleID"] = get_link_for(sample)
             item["replace"]["sample_type"] = st_link
             item["replace"]["client"] = get_link_for(client)
-            item["replace"]["state_title"] = self.get_state_title(sample)
+            state_title = self.get_sample_state_title(sample)
+            item["replace"]["state_title"] = state_title
 
             # Add an icon if last POST notification for this Sample failed
             if self.is_failed_notification(sample):
@@ -234,10 +236,7 @@ class SamplesListingView(ListingView):
         return item
 
     def get_state_title(self, obj):
-        """Translates the review state to the current set language
-        :param state: Review state title
-        :type state: basestring
-        :returns: Translated review state title
+        """Translates the review state of the object to the current language
         """
         state = api.get_review_status(obj)
         ts = api.get_tool("translation_service")
@@ -245,6 +244,16 @@ class SamplesListingView(ListingView):
         portal_type = api.get_portal_type(obj)
         state_title = wf.getTitleForStateOnType(state, portal_type)
         return ts.translate(_(state_title or state), context=self.request)
+
+    def get_sample_state_title(self, obj):
+        """Returns the state of the sample translated, along with information
+        regarding to the reception of the shipment if necessary
+        """
+        title = self.get_state_title(obj)
+        state = api.get_review_status(obj)
+        if state in ["sample_received"]:
+            return title
+        return translate("Received (${status})", mapping={"status": title})
 
     def is_failed_notification(self, obj):
         """Returns whether the last notification POST for the given object


### PR DESCRIPTION
This Pull Request ensures that the status of the sample before reception is displayed along with its current status in samples listing from inside inbound shipment.

One can reject a sample from a shipment before reception or after reception, with totally different meanings. Former means that the sample was not physically received at the laboratory, probably because it was missing in the shipment. The latter means the sample was retrieved from the shipment and physically received at the laboratory, but rejected afterwards.

![Captura de 2024-03-21 17-39-46](https://github.com/senaite/senaite.referral/assets/832627/2a13c51c-c140-49f6-8ce7-c36892e8a291)


