### PR TITLE
Add new sample status "Received at reference lab"

### DIFF
--- a/src/senaite/referral/adapters/guards/sample.py
+++ b/src/senaite/referral/adapters/guards/sample.py
@@ -68,3 +68,14 @@ class SampleGuardAdapter(BaseGuardAdapter):
         if not lab_code:
             return False
         return True
+
+    def guard_receive_at_reference(self):
+        """Returns true if current request contains a POST with the
+        'receive_at_reference' action to ensure this transition is not
+        performed manually,
+        """
+        request = api.get_request()
+        lab_code = request.get("lab_code")
+        if not lab_code:
+            return False
+        return True

--- a/src/senaite/referral/adapters/listing/samples.py
+++ b/src/senaite/referral/adapters/listing/samples.py
@@ -103,7 +103,11 @@ class SamplesListingViewAdapter(object):
             "id": "shipped",
             "title": _("Referred"),
             "contentFilter": {
-                "review_state": ("shipped", "rejected_at_reference"),
+                "review_state": (
+                    "shipped",
+                    "rejected_at_reference",
+                    "received_at_reference",
+                ),
                 "sort_on": "created",
                 "sort_order": "descending"},
             "transitions": [],

--- a/src/senaite/referral/jsonapi/outboundsample.py
+++ b/src/senaite/referral/jsonapi/outboundsample.py
@@ -65,7 +65,8 @@ class OutboundSampleConsumer(object):
                 raise APIError(500, "ValueError: {}".format(msg))
 
         # Do not allow to modify the sample if not referred
-        if api.get_review_status(sample) != "shipped":
+        statuses = ["shipped", "received_at_reference"]
+        if api.get_review_status(sample) not in statuses:
             # We don't rise an exception here because maybe the sample was
             # updated earlier, but the reference lab got a timeout error and
             # the remote user is now retrying the notification

--- a/src/senaite/referral/jsonapi/outboundsample.py
+++ b/src/senaite/referral/jsonapi/outboundsample.py
@@ -69,7 +69,8 @@ class OutboundSampleConsumer(object):
         status = api.get_review_status(sample)
         if status == "shipped":
             # TODO Do not allow the modification of 'shipped' samples
-            logger.warn("Update of samples in 'shipped' statues won't be "
+            logger.warn("Please upgrade reference instance to latest!!!. The "
+                        "update of samples in 'shipped' statues won't be "
                         "supported in the near future, but only those in "
                         "'received_at_reference' status")
 

--- a/src/senaite/referral/jsonapi/outboundsample.py
+++ b/src/senaite/referral/jsonapi/outboundsample.py
@@ -32,6 +32,7 @@ from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
 from bika.lims.interfaces import ISubmitted
 from bika.lims.utils import changeWorkflowState
 from bika.lims.workflow import doActionFor
+from senaite.referral import logger
 
 
 @implementer(IPushConsumer)
@@ -64,9 +65,15 @@ class OutboundSampleConsumer(object):
                 msg = "No retest found for '%s'" % sample_id
                 raise APIError(500, "ValueError: {}".format(msg))
 
-        # Do not allow to modify the sample if not referred
-        statuses = ["shipped", "received_at_reference"]
-        if api.get_review_status(sample) not in statuses:
+        # Do not allow to modify the sample if not received at reference
+        status = api.get_review_status(sample)
+        if status == "shipped":
+            # TODO Do not allow the modification of 'shipped' samples
+            logger.warn("Update of samples in 'shipped' statues won't be "
+                        "supported in the near future, but only those in "
+                        "'received_at_reference' status")
+
+        elif status != "received_at_reference":
             # We don't rise an exception here because maybe the sample was
             # updated earlier, but the reference lab got a timeout error and
             # the remote user is now retrying the notification

--- a/src/senaite/referral/profiles/default/metadata.xml
+++ b/src/senaite/referral/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>1006</version>
+  <version>1007</version>
 
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>

--- a/src/senaite/referral/setuphandlers.py
+++ b/src/senaite/referral/setuphandlers.py
@@ -54,8 +54,20 @@ WORKFLOWS_TO_UPDATE = {
                 "transitions": (
                     "verify",
                     "invalidate_at_reference",
+                    "receive_at_reference",
                     "reject_at_reference",
                     "recall_from_shipment"
+                ),
+                # Sample is read-only
+                "permissions_copy_from":  "invalid",
+            },
+            "received_at_reference": {
+                "title": "Received at reference lab",
+                "description": "Sample received at reference laboratory",
+                "transitions": (
+                    "verify",
+                    "reject_at_reference",
+                    "invalidate_at_reference",
                 ),
                 # Sample is read-only
                 "permissions_copy_from":  "invalid",
@@ -83,6 +95,16 @@ WORKFLOWS_TO_UPDATE = {
                     "guard_permissions": "",
                     "guard_roles": "",
                     "guard_expr": "python:here.guard_handler('ship')",
+                }
+            },
+            "receive_at_reference": {
+                "title": "Receive sample (at reference lab)",
+                "new_state": "received_at_reference",
+                "action": "Received at reference lab",
+                "guard": {
+                    "guard_permissions": "",
+                    "guard_roles": "",
+                    "guard_expr": "python:here.guard_handler('receive_at_reference')",
                 }
             },
             "reject_at_reference": {

--- a/src/senaite/referral/upgrade/v01_00_000.py
+++ b/src/senaite/referral/upgrade/v01_00_000.py
@@ -215,3 +215,13 @@ def setup_invalidate_at_reference(tool):
     setup_workflows(portal)
 
     logger.info("Setup transition 'invalidate_at_reference' [DONE]")
+
+
+def setup_receive_at_reference(tool):
+    logger.info("Setup transition 'receive_at_reference' ...")
+    portal = tool.aq_inner.aq_parent
+
+    # Setup workflows
+    setup_workflows(portal)
+
+    logger.info("Setup transition 'receive_at_reference' [DONE]")

--- a/src/senaite/referral/upgrade/v01_00_000.zcml
+++ b/src/senaite/referral/upgrade/v01_00_000.zcml
@@ -4,6 +4,14 @@
     i18n_domain="senaite.referral">
 
   <genericsetup:upgradeStep
+      title="SENAITE.REFERRAL 1.0.0: New transition: 'Receive at reference'"
+      description="Added the transition 'receive_at_reference'"
+      source="1006"
+      destination="1007"
+      handler=".v01_00_000.setup_receive_at_reference"
+      profile="senaite.referral:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.REFERRAL 1.0.0: Invalidate at reference laboratory"
       description="Added the transition 'invalidate_at_reference'"
       source="1005"

--- a/src/senaite/referral/workflow/__init__.py
+++ b/src/senaite/referral/workflow/__init__.py
@@ -103,11 +103,9 @@ def restore_referred_sample(sample):
     sample.setOutboundShipment(None)
 
     # Transition the sample and analyses to the state before sample was shipped
-    status = api.get_review_status(sample)
-    if status in ["shipped", "rejected_at_reference"]:
-        prev = get_previous_status(sample, before="shipped",
-                                   default="sample_received")
-        changeWorkflowState(sample, "bika_ar_workflow", prev)
+    previous = get_previous_status(sample, before="shipped")
+    if previous:
+        changeWorkflowState(sample, "bika_ar_workflow", previous)
 
     # Restore status of referred analyses
     wf_id = "bika_analysis_workflow"

--- a/src/senaite/referral/workflow/analysisrequest.py
+++ b/src/senaite/referral/workflow/analysisrequest.py
@@ -60,6 +60,9 @@ def AfterTransitionEventHandler(sample, event): # noqa lowercase
     if event.transition.id == "recall_from_shipment":
         restore_referred_sample(sample)
 
+    if event.transition.id == "receive":
+        after_receive(sample)
+
 
 def after_no_sampling_workflow(sample):
     """Automatically receive and ship samples for which an outbound shipment
@@ -134,6 +137,16 @@ def after_invalidate(sample):
     if referring:
         # notify the referring laboratory
         referring.do_action(sample, "invalidate_at_reference")
+
+
+def after_receive(sample):
+    """Actions to do when invalidating a sample
+    """
+    shipment = sample.getInboundShipment()
+    referring = get_remote_lab(shipment)
+    if referring:
+        # notify the referring laboratory
+        referring.do_action(sample, "receive_at_reference")
 
 
 def after_invalidate_at_reference(sample):


### PR DESCRIPTION
This Pull Request adds a new status "received_at_reference". When the sample is received in the reference lab, the referring lab is notified in accordance and the sample transitions from "shipped" to "received_at_reference". 

Samples in "received_at_reference" status cannot be recalled back from the outbound shipment, so the assignment of previously shipped (and received) samples to new shipments becomes not possible.