### PR TITLE
Fix results from hidden (but requested) tests are not updated back

### DIFF
--- a/src/senaite/referral/content/inboundsample.py
+++ b/src/senaite/referral/content/inboundsample.py
@@ -126,6 +126,12 @@ class IInboundSampleSchema(model.Schema):
     )
 
     # TODO 2.x Replace schema.List by senaite.core.schema.UIDReferenceField
+    directives.omitted("services")
+    services = schema.List(
+        title=_(u"label_inboundsample_services", default=u"Services"),
+    )
+
+    # TODO 2.x Replace schema.List by senaite.core.schema.UIDReferenceField
     directives.omitted("sample")
     sample = schema.List(
         title=_(u"label_inboundsample_sample", default=u"Sample"),
@@ -311,3 +317,21 @@ class InboundSample(Container):
         """Returns the datetime when this inbound sample was rejected or None
         """
         return get_action_date(self, "reject_inbound_sample", default=None)
+
+    def setServices(self, value):
+        """Set the services from the current instance that match with the
+        analyses that were requested by the referring laboratory
+        """
+        set_uids_field_value(self, "services", value)
+
+    def getServices(self):
+        """Returns the services from current instance that match with the
+        analyses that were requested by the referring laboratory
+        """
+        return [api.get_object(uid) for uid in self.getRawServices()]
+
+    def getRawServices(self):
+        """Returns the UIDs of the services from current instance that match
+        with the analyses that were requested by the referring laboratory
+        """
+        return get_uids_field_value(self, "services") or []

--- a/src/senaite/referral/profiles/default/metadata.xml
+++ b/src/senaite/referral/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>1007</version>
+  <version>1008</version>
 
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>

--- a/src/senaite/referral/remotelab.py
+++ b/src/senaite/referral/remotelab.py
@@ -191,26 +191,23 @@ class RemoteLab(object):
         """
 
         def get_valid_analyses(sample):
-            # Sort by id descending to prioritize newest results if retests
+            # Get the analyses from current sample that were requested by the
+            # referring laboratory, sorted by id descending to prioritize
+            # newest results if retests
+            inbound_sample = sample.getInboundSample()
+            services = inbound_sample.getRawServices()
             kwargs = {
                 "full_objects": True,
+                "getServiceUID": services,
                 "sort_on": "id",
                 "sort_order": "ascending",
             }
 
-            # Exclude old, but valid analyses with same keyword (e.g retests),
+            # exclude old, but valid analyses with same keyword (e.g retests),
             # cause we want to update the referring lab with the newest result
             analyses = {}
             valid = ["verified", "published"]
             for analysis in sample.getAnalyses(**kwargs):
-
-                # Skip analyses for internal use
-                if IInternalUse.providedBy(analysis):
-                    continue
-
-                # Skip hidden, only interested in final results
-                if analysis.getHidden():
-                    continue
 
                 # Skip analyses not in a suitable status
                 if api.get_review_status(analysis) not in valid:

--- a/src/senaite/referral/upgrade/v01_00_000.zcml
+++ b/src/senaite/referral/upgrade/v01_00_000.zcml
@@ -1,7 +1,14 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
-    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
-    i18n_domain="senaite.referral">
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
+
+  <genericsetup:upgradeStep
+      title="SENAITE.REFERRAL 1.0.0: Store service uids in inbound sample"
+      description="Store service uids in inbound sample"
+      source="1007"
+      destination="1008"
+      handler=".v01_00_000.setup_inbound_services"
+      profile="senaite.referral:default"/>
 
   <genericsetup:upgradeStep
       title="SENAITE.REFERRAL 1.0.0: New transition: 'Receive at reference'"

--- a/src/senaite/referral/workflow/inboundsample/events.py
+++ b/src/senaite/referral/workflow/inboundsample/events.py
@@ -80,9 +80,13 @@ def create_sample(inbound_sample):
     sample_type = inbound_sample.getSampleType()
     sample_type_uid = sample_types.get(sample_type)
 
+    # Resolve the service uids that match with the requested analyses
     keywords = inbound_sample.getAnalyses() or []
     services_uids = map(lambda key: services.get(key), keywords)
     services_uids = filter(api.is_uid, services_uids)
+
+    # Update the inbound sample with the service uids
+    inbound_sample.setServices(services_uids)
 
     values = {
         "Client": api.get_uid(client),


### PR DESCRIPTION
This Pull Request ensures that requested tests are updated in the referring instance even when flagged as "hidden".

With these changes, the system now keeps track of the counterpart service uids that match with the analyses that were requested by the referring lab.