### PR TITLE
Fix analyses requested by referring lab are removed after manage analyses view

### DIFF
--- a/src/senaite/referral/adapters/listing/analyses.py
+++ b/src/senaite/referral/adapters/listing/analyses.py
@@ -22,7 +22,6 @@ from senaite.core.listing.interfaces import IListingView
 from senaite.core.listing.interfaces import IListingViewAdapter
 from senaite.referral import check_installed
 from senaite.referral import messageFactory as _
-from senaite.referral.utils import get_services_mapping
 from zope.component import adapter
 from zope.interface import implementer
 
@@ -149,16 +148,7 @@ class SampleManageAnalysesListingAdapter(object):
         """
         if self._referring_services is None:
             inbound_sample = self.context.getInboundSample()
-            if not inbound_sample:
-                self._referring_services = []
-                return self._referring_services
-
-            # Look up the uids of the requested services
-            services = get_services_mapping()
-            keywords = inbound_sample.getAnalyses() or []
-            services_uids = map(lambda key: services.get(key), keywords)
-            self._referring_services = filter(api.is_uid, services_uids)
-
+            self._referring_services = inbound_sample.getRawServices()
         return self._referring_services
 
     @check_installed(None)

--- a/src/senaite/referral/browser/workflow/analysisrequest.py
+++ b/src/senaite/referral/browser/workflow/analysisrequest.py
@@ -19,8 +19,10 @@
 # Some rights reserved, see README and LICENSE.
 
 from bika.lims.browser.workflow import RequestContextAware
+from bika.lims.interfaces import IAnalysisRequest
 from bika.lims.interfaces import IWorkflowActionUIDsAdapter
 from zope.component.interfaces import implements
+from bika.lims.browser.workflow.analysisrequest import WorkflowActionSaveAnalysesAdapter
 
 
 class WorkflowActionShipAdapter(RequestContextAware):
@@ -34,3 +36,21 @@ class WorkflowActionShipAdapter(RequestContextAware):
         url = "{}/referral_ship_samples?uids={}".format(self.back_url,
                                                         ",".join(uids))
         return self.redirect(redirect_url=url)
+
+
+class SaveAnalysesAdapter(WorkflowActionSaveAnalysesAdapter):
+
+    def get_uids_from_request(self):
+        """Returns the UIDs from the request plus those from the analyses from
+        the inound shipment that were once requested, if any
+        """
+        uids = super(SaveAnalysesAdapter, self).get_uids_from_request()
+        if not IAnalysisRequest.providedBy(self.context):
+            return uids
+
+        inbound_sample = self.context.getInboundSample()
+        if not inbound_sample:
+            return uids
+
+        uids.extend(inbound_sample.getRawServices())
+        return list(set(uids))

--- a/src/senaite/referral/browser/workflow/analysisrequest.py
+++ b/src/senaite/referral/browser/workflow/analysisrequest.py
@@ -18,11 +18,13 @@
 # Copyright 2021-2022 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+from zope.component.interfaces import implements
+
 from bika.lims.browser.workflow import RequestContextAware
+from bika.lims.browser.workflow.analysisrequest import \
+    WorkflowActionSaveAnalysesAdapter
 from bika.lims.interfaces import IAnalysisRequest
 from bika.lims.interfaces import IWorkflowActionUIDsAdapter
-from zope.component.interfaces import implements
-from bika.lims.browser.workflow.analysisrequest import WorkflowActionSaveAnalysesAdapter
 
 
 class WorkflowActionShipAdapter(RequestContextAware):

--- a/src/senaite/referral/browser/workflow/configure.zcml
+++ b/src/senaite/referral/browser/workflow/configure.zcml
@@ -26,4 +26,16 @@
     provides="bika.lims.interfaces.IWorkflowActionAdapter"
     permission="zope.Public" />
 
+  <!-- Analysis Request: "save_analyses"
+  Prevents services that were initially requested by the referring laboratory
+  to be manually removed through manage_analyses view
+  -->
+  <adapter
+      name="workflow_action_save_analyses"
+      for="bika.lims.interfaces.IAnalysisRequest
+           senaite.referral.interfaces.ISenaiteReferralLayer"
+      factory=".analysisrequest.SaveAnalysesAdapter"
+      provides="bika.lims.interfaces.IWorkflowActionAdapter"
+      permission="zope.Public" />
+
 </configure>


### PR DESCRIPTION
This Pull Request fixes the issue so analyses that were initially requested by the referring laboratory are automatically removed when adding new analyses to the sample through sample's "Manage analyses" view