### PR TITLE
Keep original order of samples in outbound shipment and manifest

### DIFF
--- a/src/senaite/referral/browser/shipment_manifest.py
+++ b/src/senaite/referral/browser/shipment_manifest.py
@@ -118,10 +118,12 @@ class ShipmentManifestTemplate(BaseView):
         return self.context
 
     def get_samples(self):
-        """Returns the samples of the shipment, sorted by id ascending
+        """Returns the samples of the shipment, sorted in the same order as
+        they were initially added in the shipment
         """
-        samples = self.shipment.getSamples()
-        return sorted(samples, key=lambda sample: sample.getId())
+        # return the samples without sorting, so they are sorted in the same
+        # order as they were added, ascending
+        return self.shipment.getSamples()
 
     def to_localized_time(self, date, **kw):
         """Converts the given date to a localized time string


### PR DESCRIPTION
This Pull Request ensures the samples of an outbound shipment are sorted in the same order as they were initially added, both in listing and in the manifest

![Captura de 2024-09-26 23-59-33](https://github.com/user-attachments/assets/781a5fc0-9782-4704-a297-d08f4aee8893)

![Captura de 2024-09-27 00-04-23](https://github.com/user-attachments/assets/d15654eb-897e-41d5-ad17-3cdb8d53ba8b)
