### PR TITLE
Add default contact for ExternalLaboratory and InboundSampleShipment content

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,5 +4,5 @@ Changelog
 2.0.0 (Unreleased)
 ------------------
 
-- #31 Add default contact for ExternalLaboratory content
+- #31 Add default contact for ExternalLaboratory and InboundSampleShipment content
 - First version

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,4 +4,5 @@ Changelog
 2.0.0 (Unreleased)
 ------------------
 
+- #31 Add default contact for ExternalLaboratory content
 - First version

--- a/src/senaite/referral/browser/configure.zcml
+++ b/src/senaite/referral/browser/configure.zcml
@@ -18,6 +18,7 @@
   <include package=".theme"/>
   <include package=".viewlets"/>
   <include package=".workflow"/>
+  <include package=".form"/>
 
   <!-- Referral Control panel -->
   <browser:page

--- a/src/senaite/referral/browser/form/__init__.py
+++ b/src/senaite/referral/browser/form/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.REFERRAL.
+#
+# SENAITE.REFERRAL is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2021-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.

--- a/src/senaite/referral/browser/form/adapters/__init__.py
+++ b/src/senaite/referral/browser/form/adapters/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.REFERRAL.
+#
+# SENAITE.REFERRAL is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2021-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.

--- a/src/senaite/referral/browser/form/adapters/configure.zcml
+++ b/src/senaite/referral/browser/form/adapters/configure.zcml
@@ -1,0 +1,17 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    i18n_domain="senaite.referral">
+
+
+  <!-- Edit form handler for ExternalLaboratory -->
+  <adapter
+      for="senaite.referral.interfaces.IExternalLaboratory
+           senaite.referral.interfaces.ISenaiteReferralLayer"
+      factory=".referral.EditFormAdapter"/>
+
+  <!-- Edit form handler for InboundSampleShipment -->
+  <adapter
+      for="senaite.referral.interfaces.IInboundSampleShipment
+           senaite.referral.interfaces.ISenaiteReferralLayer"
+      factory=".referral.EditFormAdapter"/>
+</configure>

--- a/src/senaite/referral/browser/form/adapters/referral.py
+++ b/src/senaite/referral/browser/form/adapters/referral.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.REFERRAL.
+#
+# SENAITE.REFERRAL is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2021-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+
+from senaite.core.browser.form.adapters import EditFormAdapterBase
+
+WIDGET_DEFAULT_CONTACTS = "form-widgets-default_contact"
+
+
+class EditFormAdapter(EditFormAdapterBase):
+    """Edit form adapter for InboundSampleShipment
+    """
+
+    def modified(self, data):
+        name = data.get("name")
+        value = data.get("value")
+        if name == "form.widgets.referring_client":
+            client = value[0] if value else None
+            self.update_default_contacts(client)
+
+        return self.data
+
+    def update_default_contacts(self, client):
+        """Update the default contacts widget with the contacts of the client
+        """
+        query = {
+            "portal_type": "Contact",
+            "is_active": True,
+            "sort_on": "sortable_title",
+            "sort_order": "ascending",
+        }
+
+        if not client:
+            # search for all contacts
+            self.add_state_widget(WIDGET_DEFAULT_CONTACTS, query=query)
+            return
+
+        # restrict the available contacts to those of the client
+        query["getParentUID"] = client
+        self.add_state_widget(WIDGET_DEFAULT_CONTACTS, query=query)

--- a/src/senaite/referral/browser/form/configure.zcml
+++ b/src/senaite/referral/browser/form/configure.zcml
@@ -1,0 +1,6 @@
+<configure xmlns="http://namespaces.zope.org/zope">
+
+  <!-- Include child packages -->
+  <include package=".adapters"/>
+
+</configure>

--- a/src/senaite/referral/content/externallaboratory.py
+++ b/src/senaite/referral/content/externallaboratory.py
@@ -26,6 +26,7 @@ from plone.supermodel import model
 from plone.supermodel.directives import fieldset
 from Products.CMFCore import permissions
 from senaite.core.catalog import CLIENT_CATALOG
+from senaite.core.catalog import CONTACT_CATALOG
 from senaite.core.content.base import Container
 from senaite.core.schema import UIDReferenceField
 from senaite.core.z3cform.widgets.uidreference import UIDReferenceWidgetFactory
@@ -106,6 +107,26 @@ class IExternalLaboratorySchema(model.Schema):
         limit=15,
     )
 
+    default_contact = UIDReferenceField(
+        title=_(u"label_externallaboratory_default_contact",
+                default=u"Default contact"),
+        description=_(
+            U"The default contact for inbound sample shipments received from "
+            U"this external laboratory"
+        ),
+        allowed_types=("Contact",),
+        multi_valued=False,
+        required=False,
+    )
+
+    directives.widget(
+        "default_contact",
+        UIDReferenceWidgetFactory,
+        catalog=CONTACT_CATALOG,
+        query="get_contacts_query",
+        limit=15,
+    )
+
     url = schema.TextLine(
         title=_(u"label_externallaboratory_url", default=u"URL"),
         description=_(
@@ -158,7 +179,7 @@ class IExternalLaboratorySchema(model.Schema):
     fieldset(
         "referring_laboratory",
         label=_(u"Referring Laboratory"),
-        fields=["referring", "referring_client"]
+        fields=["referring", "referring_client", "default_contact"]
     )
 
     # Connectivity fieldset
@@ -215,10 +236,13 @@ class IExternalLaboratorySchema(model.Schema):
         if not value:
             return
 
-        # Check if a default client for this referring laboratory has been set
+        # Check if a default client and contact for this referring laboratory
+        # has been set
         request = api.get_request()
         client = request.form.get("form.widgets.referring_client")
-        if api.is_uid(client):
+        contact = request.form.get("form.widgets.default_contact")
+
+        if api.is_uid(client) and api.is_uid(contact):
             return
 
         # mark the request to avoid multiple raising
@@ -226,8 +250,9 @@ class IExternalLaboratorySchema(model.Schema):
         if getattr(request, key, False):
             return
         setattr(request, key, True)
-        msg = _("Please set the default client to use when creating "
-                "samples from this referring laboratory first")
+        msg = _("Please set the default client and contact to use when "
+                "creating samples from this referring laboratory first")
+
         raise Invalid(msg)
 
 
@@ -240,6 +265,27 @@ class ExternalLaboratory(Container):
 
     security = ClassSecurityInfo()
     exclude_from_nav = True
+
+    @security.private
+    def get_contacts_query(self):
+        """Return the query for the Contact field
+        """
+        query = {
+            "portal_type": "Contact",
+            "is_active": True,
+            "sort_on": "sortable_title",
+            "sort_order": "ascending",
+        }
+
+        # Get contacts belong to referring client if it is set
+        referring_client = getattr(self, "referring_client", None)
+        if referring_client:
+            client_uid = referring_client[0]
+            query["path"] = {
+                "query": api.get_path(api.get_object_by_uid(client_uid)),
+                "level": 0
+            }
+        return query
 
     @security.protected(permissions.ModifyPortalContent)
     def setReference(self, value):
@@ -372,4 +418,28 @@ class ExternalLaboratory(Container):
         requests
         """
         accessor = self.accessor("password")
+        return accessor(self)
+
+    @security.protected(permissions.ModifyPortalContent)
+    def setDefaultContact(self, value):
+        """Sets the default contact the samples from inbound shipments will
+        be assigned to
+        """
+        mutator = self.mutator("default_contact")
+        mutator(self, value)
+
+    @security.protected(permissions.View)
+    def getDefaultContact(self):
+        """Returns the default contact that samples from inbound shipments from
+        this laboratory will be assigned to
+        """
+        accessor = self.accessor("default_contact")
+        return accessor(self)
+
+    @security.protected(permissions.View)
+    def getRawDefaultContact(self):
+        """Returns the UID of the default contact that samples from inbound
+        shipments from this laboratory will be assigned to
+        """
+        accessor = self.accessor("default_contact", raw=True)
         return accessor(self)

--- a/src/senaite/referral/content/externallaboratory.py
+++ b/src/senaite/referral/content/externallaboratory.py
@@ -278,13 +278,10 @@ class ExternalLaboratory(Container):
         }
 
         # Get contacts belong to referring client if it is set
-        referring_client = getattr(self, "referring_client", None)
+        referring_client = self.getRawReferringClient()
         if referring_client:
-            client_uid = referring_client[0]
-            query["path"] = {
-                "query": api.get_path(api.get_object_by_uid(client_uid)),
-                "level": 0
-            }
+            query["getParentUID"] = referring_client
+
         return query
 
     @security.protected(permissions.ModifyPortalContent)

--- a/src/senaite/referral/content/inboundsampleshipment.py
+++ b/src/senaite/referral/content/inboundsampleshipment.py
@@ -140,22 +140,19 @@ class IInboundSampleShipmentSchema(model.Schema):
             raise ValueError("Dispatched date time is not valid")
 
     @invariant
-    def validate_referring_client(data):
-        """Checks if the referring client is set has active contacts
+    def validate_referring(data):
+        """Checks if the referring client and default contact are set
         """
-        referring_client = data.referring_client
-        if not referring_client:
+        request = api.get_request()
+        client = request.form.get("form.widgets.referring_client")
+        contact = request.form.get("form.widgets.default_contact")
+
+        if api.is_uid(client) and api.is_uid(contact):
             return
 
-        client = api.get_object_by_uid(referring_client[0])
-        if not client:
-            raise ValueError(_("Referring client not found"))
-
-        contacts = client.getContacts()
-        if len(contacts) > 0:
-            return
-
-        raise ValueError(_("Referring client has no active contacts"))
+        msg = _("Please set the default client and contact to use when "
+                "creating samples from this referring laboratory first")
+        raise ValueError(msg)
 
 
 @implementer(IInboundSampleShipment, IInboundSampleShipmentSchema)

--- a/src/senaite/referral/content/inboundsampleshipment.py
+++ b/src/senaite/referral/content/inboundsampleshipment.py
@@ -24,6 +24,7 @@ from plone.autoform import directives
 from plone.supermodel import model
 from Products.CMFCore import permissions
 from senaite.core.catalog import CLIENT_CATALOG
+from senaite.core.catalog import CONTACT_CATALOG
 from senaite.core.content.base import Container
 from senaite.core.schema import UIDReferenceField
 from senaite.core.z3cform.widgets.uidreference import UIDReferenceWidgetFactory
@@ -88,6 +89,25 @@ class IInboundSampleShipmentSchema(model.Schema):
         limit=15,
     )
 
+    default_contact = UIDReferenceField(
+        title=_(u"label_inboundsampleshipment_default_contact",
+                default=u"Default contact"),
+        description=_(
+            u"The default contact for the samples come from"
+        ),
+        allowed_types=("Contact",),
+        multi_valued=False,
+        required=True,
+    )
+
+    directives.widget(
+        "default_contact",
+        UIDReferenceWidgetFactory,
+        catalog=CONTACT_CATALOG,
+        query="get_contacts_query",
+        limit=15,
+    )
+
     comments = schema.Text(
         title=_(u"label_inboundsampleshipment_comments",
                 default=u"Comments"),
@@ -119,6 +139,24 @@ class IInboundSampleShipmentSchema(model.Schema):
         if not val:
             raise ValueError("Dispatched date time is not valid")
 
+    @invariant
+    def validate_referring_client(data):
+        """Checks if the referring client is set has active contacts
+        """
+        referring_client = data.referring_client
+        if not referring_client:
+            return
+
+        client = api.get_object_by_uid(referring_client[0])
+        if not client:
+            raise ValueError(_("Referring client not found"))
+
+        contacts = client.getContacts()
+        if len(contacts) > 0:
+            return
+
+        raise ValueError(_("Referring client has no active contacts"))
+
 
 @implementer(IInboundSampleShipment, IInboundSampleShipmentSchema)
 class InboundSampleShipment(Container):
@@ -128,6 +166,27 @@ class InboundSampleShipment(Container):
     _catalogs = [SHIPMENT_CATALOG, ]
     exclude_from_nav = True
     security = ClassSecurityInfo()
+
+    @security.private
+    def get_contacts_query(self):
+        """Return the query for the Contact field
+        """
+        query = {
+            "portal_type": "Contact",
+            "is_active": True,
+            "sort_on": "sortable_title",
+            "sort_order": "ascending",
+        }
+
+        # Get contacts belong to referring client if it is set
+        referring_client = getattr(self, "referring_client", None)
+        if referring_client:
+            client_uid = referring_client[0]
+            query["path"] = {
+                "query": api.get_path(api.get_object_by_uid(client_uid)),
+                "level": 0
+            }
+        return query
 
     def _get_title(self):
         return self.getShipmentID()
@@ -249,3 +308,27 @@ class InboundSampleShipment(Container):
         query = {"UID": uids}
         samples = api.search(query, "uid_catalog")
         return [api.get_object(sample) for sample in samples]
+
+    @security.protected(permissions.ModifyPortalContent)
+    def setDefaultContact(self, value):
+        """Sets the default contact the samples from inbound shipments will
+        be assigned to
+        """
+        mutator = self.mutator("default_contact")
+        mutator(self, value)
+
+    @security.protected(permissions.View)
+    def getDefaultContact(self):
+        """Returns the default contact that samples from inbound shipments from
+        this laboratory will be assigned to
+        """
+        accessor = self.accessor("default_contact")
+        return accessor(self)
+
+    @security.protected(permissions.View)
+    def getRawDefaultContact(self):
+        """Returns the UID of the default contact that samples from inbound
+        shipments from this laboratory will be assigned to
+        """
+        accessor = self.accessor("default_contact", raw=True)
+        return accessor(self)

--- a/src/senaite/referral/jsonapi/inboundshipment.py
+++ b/src/senaite/referral/jsonapi/inboundshipment.py
@@ -89,6 +89,7 @@ class InboundShipmentConsumer(object):
             "shipment_id": str(shipment_id),
             "referring_laboratory": api.get_uid(lab),
             "referring_client": lab.getRawReferringClient(),
+            "default_contact": lab.getRawDefaultContact(),
             "comments": str(comments),
             "dispatched_datetime": DT2dt(dispatched_date),
             "samples": sample_records,

--- a/src/senaite/referral/workflow/inboundsample/events.py
+++ b/src/senaite/referral/workflow/inboundsample/events.py
@@ -71,6 +71,10 @@ def create_sample(inbound_sample):
     client = shipment.getReferringClient()
     client = api.get_object(client)
 
+    # Get the default contact for this shipment
+    contact = shipment.getDefaultContact()
+    contact = api.get_object(contact)
+
     # Get baseline objects mappings
     services = get_services_mapping()
     sample_types = get_sample_types_mapping()
@@ -91,7 +95,7 @@ def create_sample(inbound_sample):
 
     values = {
         "Client": api.get_uid(client),
-        "Contact": None,
+        "Contact": api.get_uid(contact),
         "ClientSampleID": inbound_sample.getReferringID(),
         "DateSampled": inbound_sample.getDateSampled(),
         "SampleType": sample_type_uid,


### PR DESCRIPTION
> [!WARNING]  
> Merge https://github.com/senaite/senaite.core/pull/2705 first

## Description of the issue/feature this PR addresses
This Pull Request adds default contact field for ExternalLaboratory and InboundSampleShipment content

## Current behavior before PR
Default contact is not displayed in Referring Laboratory and Inbound Sample Shipment

## Desired behavior after PR is merged
Default contact is displayed in Referring Laboratory and Inbound Sample Shipment

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8](https://www.python.org/dev/peps/pep-0008)
and [Plone's Python styleguide](https://docs.plone.org/develop/styleguide/python.html) standards.

