### PR TITLE
Fix build test after adding default contact

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,5 +4,6 @@ Changelog
 2.0.0 (Unreleased)
 ------------------
 
+- #32 Fix build test after adding default contact
 - #31 Add default contact for ExternalLaboratory and InboundSampleShipment content
 - First version

--- a/src/senaite/referral/tests/doctests/IDServer.rst
+++ b/src/senaite/referral/tests/doctests/IDServer.rst
@@ -151,9 +151,11 @@ shipments are created through a push consumer - see PushConsumer.rst):
 
     >>> lab = filter(lambda lab: lab.code == "EXT2", labs)[0]
     >>> client = filter(lambda cl: cl.getClientID() == "HH", clients)[0]
+    >>> contact = client.getContacts()[0]
     >>> values = {
     ...     "referring_laboratory": api.get_uid(lab),
     ...     "referring_client": api.get_uid(client),
+    ...     "default_contact": api.get_uid(contact),
     ...     "comments": "Test inbound sample shipment",
     ...     "dispatched_datetime": datetime.now() - timedelta(days=2)
     ... }
@@ -193,9 +195,11 @@ Manually create an inbound shipment:
 
     >>> lab = filter(lambda lab: lab.code == "EXT2", labs)[0]
     >>> client = filter(lambda cl: cl.getClientID() == "HH", clients)[0]
+    >>> contact = client.getContacts()[0]
     >>> values = {
     ...     "referring_laboratory": api.get_uid(lab),
     ...     "referring_client": api.get_uid(client),
+    ...     "default_contact": api.get_uid(contact),
     ...     "comments": "Test inbound sample shipment 2",
     ...     "dispatched_datetime": datetime.now() - timedelta(days=2)
     ... }


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
Fixes the failing test suite (`bin/test -s senaite.referral`) after merging PR #31, which introduced a default contact.

## Current behavior before PR
After merging PR #31, the test suite fails when running bin/test -s senaite.referral due to changes related to the default contact setup.

## Desired behavior after PR is merged
All tests should pass successfully when running bin/test -s senaite.referral, ensuring the build is stable and compatible with the changes introduced in PR #31

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8](https://www.python.org/dev/peps/pep-0008)
and [Plone's Python styleguide](https://docs.plone.org/develop/styleguide/python.html) standards.

