### PR TITLE
Add RejectionReasons field to InboundSample content

### DIFF
--- a/src/senaite/referral/browser/inbound/configure.zcml
+++ b/src/senaite/referral/browser/inbound/configure.zcml
@@ -20,4 +20,12 @@
       permission="zope2.View"
       layer="senaite.referral.interfaces.ISenaiteReferralLayer" />
 
+  <!-- Inbound Sample Reject view -->
+  <browser:page
+      for="*"
+      name="reject_inbound_sample"
+      class=".samples.RejectInboundSamplesView"
+      permission="zope2.View"
+      layer="senaite.referral.interfaces.ISenaiteReferralLayer"
+    />
 </configure>

--- a/src/senaite/referral/browser/inbound/samples.py
+++ b/src/senaite/referral/browser/inbound/samples.py
@@ -19,13 +19,17 @@
 # Some rights reserved, see README and LICENSE.
 
 import collections
+from bika.lims.workflow import doActionFor
+import six
 
 from bika.lims import api
 from bika.lims import PRIORITIES
+from bika.lims.browser import BrowserView
 from bika.lims.utils import get_image
 from bika.lims.utils import get_link_for
 from bika.lims.utils import render_html_attributes
 from plone.memoize import view
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from senaite.app.listing import ListingView
 from senaite.core.api import dtime
 from senaite.referral import messageFactory as _
@@ -294,3 +298,74 @@ class SamplesListingView(ListingView):
         """
         sample_types = self.get_sample_types()
         return sample_types.get(term)
+
+
+class RejectInboundSamplesView(BrowserView):
+    """View that renders the InboundSamples rejection view
+    """
+    template = ViewPageTemplateFile("templates/reject_inbound_sample.pt")
+
+    def __init__(self, context, request):
+        super(RejectInboundSamplesView, self).__init__(context, request)
+        self.context = context
+        self.request = request
+
+    def __call__(self):
+        # Form submit
+        form = self.request.form
+
+        # Handle form submission
+        if form.get("submit", None) == "Reject":
+            reasons = form.get("reasons", [])
+            if not reasons:
+                message = _("Please select at least one rejection reason")
+                self.context.plone_utils.addPortalMessage(message, "error")
+                return self.template()
+
+            # Reject each inbound sample with the given reasons
+            shipment = None
+            inbound_samples = self.retrieve_inbound_samples()
+
+            for sample in inbound_samples:
+                shipment = shipment or sample.aq_parent
+                doActionFor(sample, "reject_inbound_sample", reasons=reasons)
+
+            # Redirect to the inbound shipment
+            if shipment:
+                self.request.response.redirect(shipment.absolute_url())
+                return
+
+            # No shipment found - shouldn't happen
+            url = self.request.get_header(
+                "referer", self.context.absolute_url()
+            )
+            self.request.response.redirect(url)
+            return
+
+        return self.template()
+
+    def retrieve_inbound_samples(self):
+        """Retrieves the inbound samples from request
+        """
+        inbound_samples = []
+        # Get the UIDs of the inbound samples from the request
+        uids = self.request.form.get("uids", [])
+        if isinstance(uids, six.string_types):
+            uids = uids.split(",")
+
+        uids = list(set(uids))
+        if not uids:
+            return []
+
+        query = dict(portal_type="InboundSample", UID=uids)
+        for brain in api.search(query):
+            inbound_sample = api.get_object(brain)
+            inbound_samples.append(inbound_sample)
+
+        return inbound_samples
+
+    @view.memoize
+    def get_rejection_options(self):
+        """Returns the list of available rejection reasons
+        """
+        return api.get_setup().getRejectionReasonsItems()

--- a/src/senaite/referral/browser/inbound/templates/reject_inbound_sample.pt
+++ b/src/senaite/referral/browser/inbound/templates/reject_inbound_sample.pt
@@ -1,0 +1,100 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      metal:use-macro="here/main_template/macros/master"
+      i18n:domain="senaite.referral">
+
+<body>
+
+<metal:content-title fill-slot="content-title">
+  <h1 i18n:translate="">
+    Reject Inbound Sample(s)
+  </h1>
+</metal:content-title>
+
+<metal:content-description fill-slot="content-description">
+  <p i18n:translate="">
+    Assign reasons for rejecting inbound sample(s)
+  </p>
+</metal:content-description>
+
+<metal:content-core fill-slot="content-core">
+  <div id="reject-inbound-sample-form"
+       class="row"
+       tal:define="samples view/inbound_samples">
+
+    <tal:nosamples tal:condition="not:samples">
+      <p i18n:translate="">No inbound samples selected for rejection</p>
+    </tal:nosamples>
+
+    <tal:hassamples tal:condition="samples">
+      <form method="POST">
+        <input type="hidden" name="submitted" value="1"/>
+        <input tal:repeat="sample samples"
+               type="hidden" name="uids:list" 
+               tal:attributes="value sample/UID"/>
+
+        <div class="col-sm-12">
+          <div class="form-group">
+            <label i18n:translate="">
+              Selected Inbound Samples
+            </label>
+            <table class="table table-bordered table-striped">
+              <thead>
+                <tr>
+                  <th i18n:translate="">Sample ID</th>
+                  <th i18n:translate="">Sample Type</th>
+                  <th i18n:translate="">Date Sampled</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr tal:repeat="sample samples">
+                  <td tal:content="sample/getId">ID</td>
+                  <td tal:content="sample/getSampleType">Type</td>
+                  <td tal:content="sample/getSamplingDate">Date</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="form-group">
+            <label i18n:translate="">
+              Rejection Reasons
+            </label>
+            <div class="help-block" i18n:translate="">
+              Please select at least one reason for rejection
+            </div>
+            <div class="checkbox" tal:repeat="option view/get_rejection_options">
+              <label>
+                <input type="checkbox" 
+                       name="reasons:list"
+                       tal:attributes="value option/value"/>
+                <span tal:content="option/title">Reason</span>
+              </label>
+            </div>
+            <div class="form-group">
+              <label i18n:translate="">Other Reasons</label>
+              <textarea class="form-control" 
+                        name="reasons:list" 
+                        rows="3"></textarea>
+            </div>
+          </div>
+
+          <div class="form-group text-right">
+            <input type="submit" 
+                   class="btn btn-danger"
+                   name="submit" 
+                   value="Reject"
+                   i18n:attributes="value"/>
+            <a class="btn btn-default"
+               tal:attributes="href python:request.get('HTTP_REFERER', view.context.absolute_url())"
+               i18n:translate="">Cancel</a>
+          </div>
+        </div>
+      </form>
+    </tal:hassamples>
+  </div>
+</metal:content-core>
+
+</body>
+</html>

--- a/src/senaite/referral/browser/viewlets/configure.zcml
+++ b/src/senaite/referral/browser/viewlets/configure.zcml
@@ -52,4 +52,14 @@
       permission="zope2.View"
       layer="senaite.referral.interfaces.ISenaiteReferralLayer" />
 
+  <!-- Rejected Inbound Samples viewlet -->
+  <browser:viewlet
+      for="senaite.referral.interfaces.IInboundSampleShipment"
+      name="senaite.referral.viewlet.rejected_samples"
+      class=".rejected_samples.RejectedSamplesViewlet"
+      manager="plone.app.layout.viewlets.interfaces.IAboveContentBody"
+      template="templates/rejected_samples_viewlet.pt"
+      permission="zope2.View"
+      layer="senaite.referral.interfaces.ISenaiteReferralLayer" />
+
 </configure>

--- a/src/senaite/referral/browser/viewlets/rejected_samples.py
+++ b/src/senaite/referral/browser/viewlets/rejected_samples.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.REFERRAL.
+#
+# SENAITE.REFERRAL is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2021-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from plone.app.layout.viewlets import ViewletBase
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from senaite.referral.interfaces import IInboundSampleShipment
+
+
+class RejectedSamplesViewlet(ViewletBase):
+    """Displays information about rejected inbound samples
+    """
+    template = ViewPageTemplateFile("templates/rejected_samples_viewlet.pt")
+
+    def __init__(self, context, request, view, manager):
+        super(RejectedSamplesViewlet, self).__init__(
+            context, request, view, manager)
+        self.context = context
+        self.request = request
+        self.view = view
+
+    def index(self):
+        if not IInboundSampleShipment.providedBy(self.context):
+            return ""
+
+        # Get rejected inbound samples
+        rejected_samples = []
+        for sample in self.context.getInboundSamples():
+            if sample.isRejected():
+                rejected_samples.append(sample)
+
+        if not rejected_samples:
+            return ""
+
+        self.rejected_samples = rejected_samples
+        return self.template()

--- a/src/senaite/referral/browser/viewlets/templates/rejected_samples_viewlet.pt
+++ b/src/senaite/referral/browser/viewlets/templates/rejected_samples_viewlet.pt
@@ -1,0 +1,17 @@
+<div class="alert alert-danger"
+     tal:define="samples view/rejected_samples">
+  
+  <h4 i18n:translate="">The following inbound samples were rejected:</h4>
+  
+  <div tal:repeat="sample samples">
+    <p>
+      <strong tal:content="sample/getId">ID</strong>
+      <tal:reasons tal:define="reasons sample/getRejectionReasons">
+        <tal:hasreasons tal:condition="reasons">
+          <span i18n:translate="">Reasons</span>:
+          <span tal:replace="python:','.join(reasons)"></span>
+        </tal:hasreasons>
+      </tal:reasons>
+    </p>
+  </div>
+</div>

--- a/src/senaite/referral/configure.zcml
+++ b/src/senaite/referral/configure.zcml
@@ -31,6 +31,9 @@
       component="senaite.referral.vocabularies.ReferenceLaboratoriesVocabularyFactory"
       name="senaite.referral.vocabularies.referencelaboratories" />
 
+  <utility
+      component="senaite.referral.vocabularies.RejectionReasonsVocabularyFactory"
+      name="senaite.referral.vocabularies.rejection_reasons" />
 
   <!-- Default profile -->
   <genericsetup:registerProfile

--- a/src/senaite/referral/content/inboundsample.py
+++ b/src/senaite/referral/content/inboundsample.py
@@ -35,6 +35,7 @@ from senaite.referral.content import set_string_value
 from senaite.referral.content import set_uids_field_value
 from senaite.referral.interfaces import IInboundSample
 from senaite.referral.utils import get_action_date
+from z3c.form.browser.checkbox import CheckBoxFieldWidget
 from zope import schema
 from zope.interface import implementer
 from zope.interface import Invalid
@@ -46,7 +47,7 @@ from bika.lims import api
 def is_referring_id_unique(instance, referring_id):
     """Checks whether the referring id passed-in is unique
     """
-    query = {"portal_type": "InboundSample", "referring_id": referring_id }
+    query = {"portal_type": "InboundSample", "referring_id": referring_id}
     brains = api.search(query, catalog=INBOUND_SAMPLE_CATALOG)
     if not brains:
         return True
@@ -142,13 +143,26 @@ class IInboundSampleSchema(model.Schema):
     )
 
     # Add the field RejectionReasons to InboundSample type
-    rejection_reasons = schema.Choice(
-        title=_(
-            u"label_inboundsample_rejection_reasons",
-            default=u"Sample Rejection Reasons"
+    model.fieldset(
+        'rejection',
+        label=_('Rejection'),
+        fields=['rejection_reasons', 'rejection_other']
+    )
+
+    rejection_reasons = schema.Set(
+        title=_("Rejection reasons"),
+        description=_("Select predefined rejection reasons"),
+        value_type=schema.Choice(
+            title=_("Rejection reasons"),
+            vocabulary="senaite.core.rejectionreasons"
         ),
-        description=_(u"Sample Rejection Reasons"),
-        vocabulary="senaite.referral.vocabularies.rejection_reasons",
+        required=False,
+    )
+    directives.widget('rejection_reasons', CheckBoxFieldWidget)
+
+    rejection_other = schema.Text(
+        title=_("Other rejection reasons"),
+        description=_("Describe other rejection reasons not predefined"),
         required=False,
     )
 

--- a/src/senaite/referral/content/inboundsample.py
+++ b/src/senaite/referral/content/inboundsample.py
@@ -141,6 +141,17 @@ class IInboundSampleSchema(model.Schema):
         )
     )
 
+    # Add the field RejectionReasons to InboundSample type
+    rejection_reasons = schema.Choice(
+        title=_(
+            u"label_inboundsample_rejection_reasons",
+            default=u"Sample Rejection Reasons"
+        ),
+        description=_(u"Sample Rejection Reasons"),
+        vocabulary="senaite.referral.vocabularies.rejection_reasons",
+        required=False,
+    )
+
     @invariant
     def validate_referring_id(data):
         """Checks if the value for field referring_id is valid
@@ -335,3 +346,13 @@ class InboundSample(Container):
         with the analyses that were requested by the referring laboratory
         """
         return get_uids_field_value(self, "services") or []
+
+    @security.protected(permissions.View)
+    def getRejectionReasons(self):
+        accessor = self.accessor("rejection_reasons")
+        return accessor(self)
+
+    @security.protected(permissions.ModifyPortalContent)
+    def setRejectionReasons(self, value):
+        mutator = self.mutator("rejection_reasons")
+        mutator(self, value)

--- a/src/senaite/referral/jsonapi/consumer.py
+++ b/src/senaite/referral/jsonapi/consumer.py
@@ -281,3 +281,11 @@ class ReferralConsumer(BaseConsumer):
         """
         statuses = ["invalid", "invalidated_at_reference"]
         return api.get_review_status(sample) in statuses
+
+    def do_inbound_sample_reject(self, item):
+        shipment = self.get_object_for(item)
+        self.do_action(shipment, "reject_inbound_sample")
+        for sample in shipment.getInboundSamples():
+            rejection_reasons = self.get_value(sample, "RejectionReasons")
+            sample.setRejectionReasons(rejection_reasons)
+            self.do_action(sample, "reject_at_reference")

--- a/src/senaite/referral/jsonapi/consumer.py
+++ b/src/senaite/referral/jsonapi/consumer.py
@@ -27,7 +27,6 @@ from senaite.referral import utils
 from senaite.referral.catalog import SHIPMENT_CATALOG
 from senaite.referral.workflow import change_workflow_state
 from zope.interface import implementer
-
 from bika.lims import api
 from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
 from bika.lims.workflow import doActionFor
@@ -282,10 +281,17 @@ class ReferralConsumer(BaseConsumer):
         statuses = ["invalid", "invalidated_at_reference"]
         return api.get_review_status(sample) in statuses
 
-    def do_inbound_sample_reject(self, item):
-        shipment = self.get_object_for(item)
-        self.do_action(shipment, "reject_inbound_sample")
-        for sample in shipment.getInboundSamples():
-            rejection_reasons = self.get_value(sample, "RejectionReasons")
-            sample.setRejectionReasons(rejection_reasons)
-            self.do_action(sample, "reject_at_reference")
+    def do_inboundsample_reject(inbound_sample, response):
+        """Rejects an inbound sample
+        """
+        # Get the rejection reasons from the request data
+        request_data = response.get("request_data", {})
+        reasons = request_data.get("reasons", [])
+
+        # Store the rejection reasons
+        if reasons:
+            inbound_sample.setRejectionReasons(reasons)
+
+        # Do the transition
+        doActionFor(inbound_sample, "reject_inbound_sample")
+        return True

--- a/src/senaite/referral/profiles/default/workflows/senaite_inbound_sample_workflow/definition.xml
+++ b/src/senaite/referral/profiles/default/workflows/senaite_inbound_sample_workflow/definition.xml
@@ -68,7 +68,7 @@
 
   <!-- Transition: reject_inbound_sample -->
   <transition transition_id="reject_inbound_sample" title="Reject" new_state="rejected" trigger="USER" before_script="" after_script="" i18n:attributes="title">
-    <action url="" category="workflow" icon="">Reject</action>
+    <action url="reject_inbound_sample?uids=${object_uid}" category="workflow" icon="">Reject</action>
     <guard>
       <guard-expression>python:here.guard_handler("reject_inbound_sample")</guard-expression>
     </guard>

--- a/src/senaite/referral/vocabularies.py
+++ b/src/senaite/referral/vocabularies.py
@@ -22,7 +22,6 @@ from zope.interface import implementer
 from zope.schema.interfaces import IVocabularyFactory
 from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
-from zope.site.hooks import getSite
 
 from bika.lims import api
 
@@ -74,24 +73,15 @@ ReferenceLaboratoriesVocabularyFactory = ReferenceLaboratoriesVocabulary()
 
 @implementer(IVocabularyFactory)
 class RejectionReasonsVocabulary(object):
+    """Vocabulary factory for rejection reasons
+    """
 
     def __call__(self, context):
-        plone = getSite()
-        settings = plone.bika_setup
-
-        if len(settings.RejectionReasons) > 0:
-            reject_reasons = settings.RejectionReasons[0]
-        else:
-            return []
-
-        sorted_keys = sorted(reject_reasons.keys())
-        if 'checkbox' in sorted_keys:
-            sorted_keys.remove('checkbox')
-
-        items = []
-        for key in sorted_keys:
-            items.append(reject_reasons[key].strip())
-        return SimpleVocabulary(items)
+        setup = api.get_setup()
+        items = setup.getRejectionReasonsItems()
+        return SimpleVocabulary(
+            [SimpleTerm(item, item, item) for item in items]
+        )
 
 
 RejectionReasonsVocabularyFactory = RejectionReasonsVocabulary()

--- a/src/senaite/referral/vocabularies.py
+++ b/src/senaite/referral/vocabularies.py
@@ -22,6 +22,7 @@ from zope.interface import implementer
 from zope.schema.interfaces import IVocabularyFactory
 from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
+from zope.site.hooks import getSite
 
 from bika.lims import api
 
@@ -69,3 +70,28 @@ class ReferenceLaboratoriesVocabulary(object):
 
 
 ReferenceLaboratoriesVocabularyFactory = ReferenceLaboratoriesVocabulary()
+
+
+@implementer(IVocabularyFactory)
+class RejectionReasonsVocabulary(object):
+
+    def __call__(self, context):
+        plone = getSite()
+        settings = plone.bika_setup
+
+        if len(settings.RejectionReasons) > 0:
+            reject_reasons = settings.RejectionReasons[0]
+        else:
+            return []
+
+        sorted_keys = sorted(reject_reasons.keys())
+        if 'checkbox' in sorted_keys:
+            sorted_keys.remove('checkbox')
+
+        items = []
+        for key in sorted_keys:
+            items.append(reject_reasons[key].strip())
+        return SimpleVocabulary(items)
+
+
+RejectionReasonsVocabularyFactory = RejectionReasonsVocabulary()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
This PR adds support for rejecting inbound samples with specified rejection reasons

## Current behavior before PR
No field for rejection reasons

## Desired behavior after PR is merged
- RejectionReasons added to InboundSample
- New view for assigning rejection reasons 

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
