### PR TITLE
Rejection inbound samples

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (Unreleased)
 ------------------
 
+- #35 Rejection inbound samples
 - #32 Fix build test after adding default contact
 - #31 Add default contact for ExternalLaboratory and InboundSampleShipment content
 - First version

--- a/src/senaite/referral/browser/inbound/samples/__init__.py
+++ b/src/senaite/referral/browser/inbound/samples/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.REFERRAL.
+#
+# SENAITE.REFERRAL is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2021-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.

--- a/src/senaite/referral/browser/inbound/samples/configure.zcml
+++ b/src/senaite/referral/browser/inbound/samples/configure.zcml
@@ -4,14 +4,13 @@
     i18n_domain="senaite.referral">
 
   <!-- Package includes -->
-  <include package=".samples"/>
+  <include package=".rejection"/>
 
-  <!-- Inbound Sample Shipment view -->
+  <!-- Inbound Sample Shipment's samples listing -->
   <browser:page
-      name="view"
+      name="samples_listing"
       for="senaite.referral.interfaces.IInboundSampleShipment"
-      class=".view.InboundSamplesShipmentView"
-      template="templates/view.pt"
+      class=".view.SamplesListingView"
       permission="zope2.View"
       layer="senaite.referral.interfaces.ISenaiteReferralLayer" />
 

--- a/src/senaite/referral/browser/inbound/samples/rejection/__init__.py
+++ b/src/senaite/referral/browser/inbound/samples/rejection/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.REFERRAL.
+#
+# SENAITE.REFERRAL is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2021-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.

--- a/src/senaite/referral/browser/inbound/samples/rejection/configure.zcml
+++ b/src/senaite/referral/browser/inbound/samples/rejection/configure.zcml
@@ -1,0 +1,14 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser"
+    i18n_domain="senaite.referral">
+
+  <!-- Reject Inbound Samples View -->
+  <browser:page
+      for="*"
+      name="reject_inbound_samples"
+      class=".reject_inbound_samples.RejectInboundSamplesView"
+      permission="senaite.core.permissions.ManageBika"
+      layer="senaite.referral.interfaces.ISenaiteReferralLayer" />
+
+</configure>

--- a/src/senaite/referral/browser/inbound/samples/rejection/reject_inbound_samples.py
+++ b/src/senaite/referral/browser/inbound/samples/rejection/reject_inbound_samples.py
@@ -38,7 +38,7 @@ class RejectInboundSamplesView(BrowserView):
         super(RejectInboundSamplesView, self).__init__(context, request)
         self.context = context
         self.request = request
-        self.back_url = self.context.absolute_url()
+        self.back_url = api.get_url(self.context.getInboundShipment())
 
     def __call__(self):
         form = self.request.form
@@ -73,15 +73,10 @@ class RejectInboundSamplesView(BrowserView):
                 if not any([reasons, other]):
                     continue
 
-                # This is quite bizarre!
-                # AR's Rejection reasons is a RecordsField, but with one
-                # record only, that contains both predefined and other reasons.
                 obj = api.get_object_by_uid(inbound_sample_uid)
-                rejection_reasons = {
-                    "other": other,
-                    "selected": reasons
-                }
-                obj.setRejectionReasons([rejection_reasons])
+
+                obj.setSelectedRejectionReasons(reasons)
+                obj.setOtherRejectionReasons(other)
 
                 # Reject the sample
                 processed.append(obj)

--- a/src/senaite/referral/browser/inbound/samples/rejection/reject_inbound_samples.py
+++ b/src/senaite/referral/browser/inbound/samples/rejection/reject_inbound_samples.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.REFERRAL.
+#
+# SENAITE.REFERRAL is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2021-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+import six
+from bika.lims import api
+from bika.lims import senaiteMessageFactory as _
+from plone.memoize import view
+from Products.Five.browser import BrowserView
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from senaite.core import logger
+from senaite.core.api.dtime import to_localized_time
+from senaite.referral.catalog import INBOUND_SAMPLE_CATALOG
+
+
+class RejectInboundSamplesView(BrowserView):
+    """View that renders the Inbound Samples rejection view
+    """
+    template = ViewPageTemplateFile("templates/reject_inbound_samples.pt")
+
+    def __init__(self, context, request):
+        super(RejectInboundSamplesView, self).__init__(context, request)
+        self.context = context
+        self.request = request
+        self.back_url = self.context.absolute_url()
+
+    def __call__(self):
+        form = self.request.form
+
+        # Form submit toggle
+        form_submitted = form.get("submitted", False)
+
+        # Buttons
+        form_continue = form.get("button_continue", False)
+        form_cancel = form.get("button_cancel", False)
+
+        # Get the objects from request
+        inbound_samples = self.get_inbound_samples_from_request()
+
+        # No Inbound Samples selected
+        if not inbound_samples:
+            return self.redirect(message=_("No items selected"),
+                                 level="warning")
+
+        # Handle rejection
+        if form_submitted and form_continue:
+            logger.info("*** REJECT INBOUND SAMPLES ***")
+            processed = []
+            for inbound_sample in form.get("inbound_samples", []):
+                inbound_sample_uid = inbound_sample.get("uid", "")
+                reasons = inbound_sample.get("reasons", [])
+                other = inbound_sample.get("other_reasons", "")
+                if not inbound_sample_uid:
+                    continue
+
+                # Omit if no rejection reason specified
+                if not any([reasons, other]):
+                    continue
+
+                # This is quite bizarre!
+                # AR's Rejection reasons is a RecordsField, but with one
+                # record only, that contains both predefined and other reasons.
+                obj = api.get_object_by_uid(inbound_sample_uid)
+                rejection_reasons = {
+                    "other": other,
+                    "selected": reasons
+                }
+                obj.setRejectionReasons([rejection_reasons])
+
+                # Reject the sample
+                processed.append(obj)
+
+            if not processed:
+                return self.redirect(message=_("No samples were rejected"))
+
+            message = _("Rejected {} samples: {}").format(
+                len(processed), ", ".join(map(api.get_id, processed)))
+            return self.redirect(message=message)
+
+        # Handle cancel
+        if form_submitted and form_cancel:
+            logger.info("*** CANCEL REJECTION ***")
+            return self.redirect(message=_("Rejection cancelled"))
+
+        return self.template()
+
+    @view.memoize
+    def get_inbound_samples_from_request(self):
+        """Returns a list of objects coming from the "uids" request parameter
+        """
+        uids = self.request.form.get("uids", "")
+        if isinstance(uids, six.string_types):
+            uids = uids.split(",")
+
+        uids = list(set(uids))
+        if not uids:
+            return []
+
+        inbound_samples = []
+        query = dict(portal_type="InboundSample", UID=uids)
+        for brain in api.search(query, INBOUND_SAMPLE_CATALOG):
+            inbound_sample = api.get_object(brain)
+            inbound_samples.append(inbound_sample)
+        return inbound_samples
+
+    @view.memoize
+    def get_rejection_reasons(self):
+        """Returns the list of available rejection reasons
+        """
+        return api.get_setup().getRejectionReasonsItems()
+
+    def get_inbound_samples_data(self):
+        """Returns a list of Inbound Samples data (dictionary)
+        """
+        for obj in self.get_inbound_samples_from_request():
+            yield {
+                "obj": obj,
+                "id": api.get_id(obj),
+                "uid": api.get_uid(obj),
+                "title": obj.Title(),
+                "sample_type": obj.getSampleType(),
+                "analyses": obj.getAnalyses(),
+                "date": to_localized_time(
+                    obj.getDateSampled(), long_format=True
+                ),
+            }
+
+    def redirect(self, redirect_url=None, message=None, level="info"):
+        """Redirect with a message
+        """
+        if redirect_url is None:
+            redirect_url = self.back_url
+        if message is not None:
+            self.add_status_message(message, level)
+        return self.request.response.redirect(redirect_url)
+
+    def add_status_message(self, message, level="info"):
+        """Set a portal status message
+        """
+        return self.context.plone_utils.addPortalMessage(message, level)

--- a/src/senaite/referral/browser/inbound/samples/rejection/templates/reject_inbound_samples.pt
+++ b/src/senaite/referral/browser/inbound/samples/rejection/templates/reject_inbound_samples.pt
@@ -1,0 +1,131 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      metal:use-macro="here/main_template/macros/master"
+      i18n:domain="senaite.referral">
+
+  <head>
+    <metal:block fill-slot="senaite_legacy_resources"
+                 tal:define="portal context/@@plone_portal_state/portal;">
+    </metal:block>
+  </head>
+
+  <body>
+
+    <!-- Title -->
+    <metal:title fill-slot="content-title">
+      <h2 i18n:translate="" class="d-inline align-middle">
+        Reject Inbound Samples
+      </h2>
+    </metal:title>
+
+    <!-- Description -->
+    <metal:description fill-slot="content-description">
+    </metal:description>
+
+    <!-- Content -->
+    <metal:core fill-slot="content-core">
+
+      <div class="d-flex mb-3">
+        <a href="#" class="btn btn-outline-secondary"
+           tal:attributes="href python:context.absolute_url()"
+           i18n:translate="">
+            &larr; Go back</a>
+      </div>
+
+      <div id="reject-samples-view"
+           tal:define="portal context/@@plone_portal_state/portal;">
+
+        <form class="form"
+              id="reject_samples_form"
+              name="reject_samples_form"
+              method="POST">
+
+          <!-- Hidden Fields -->
+          <input type="hidden" name="submitted" value="1"/>
+          <input tal:replace="structure context/@@authenticator/authenticator"/>
+
+          <tal:samples repeat="inbound_sample view/get_inbound_samples_data">
+
+            <!-- Remember the initial UIDs coming in -->
+            <input type="hidden" name="uids:list"
+                   tal:attributes="value inbound_sample/uid"/>
+
+            <div class="card mb-3">
+
+              <div class="card-header">
+                <!-- Origin Sample ID -->
+                <div tal:content="inbound_sample/title"></div>
+
+                <!-- Sample Type -->
+                <div class="d-inline-flex">
+                  <div tal:content="inbound_sample/sample_type"></div>
+                </div>
+
+                <!-- Analyses -->
+                <div class="d-inline-flex">
+                  <div tal:content="inbound_sample/analyses"></div>
+                </div>
+              </div>
+
+              <div class="card-body"
+                   tal:define="reasons python: view.get_rejection_reasons()">
+
+                <input type="hidden" name="inbound_samples.uid:records"
+                       tal:attributes="value inbound_sample/uid"/>
+
+                <!-- Pre-defined rejection reasons -->
+                <div class="form-group field">
+                  <label class="font-weight-bold" i18n:translate="">
+                    Rejection reasons
+                  </label>
+                  <div tal:condition="reasons" tal:repeat="reason reasons">
+                    <input type="checkbox"
+                           tal:attributes="name string:samples.reasons:records:list;
+                                           value reason"/>
+                    <span tal:content="reason"></span>
+                  </div>
+                  <div tal:condition="python: not reasons" i18n:translate="">
+                    There are no pre-defined conditions set
+                  </div>
+                </div>
+
+                <!-- Other rejection reasons -->
+                <div class="form-group">
+                  <label class="font-weight-bold"
+                         tal:condition="reasons" i18n:translate="">
+                    Other reasons
+                  </label>
+                  <label class="font-weight-bold"
+                         tal:condition="python: not reasons"
+                         i18n:translate="">
+                    Rejection reasons
+                  </label>
+                  <textarea rows="5" class="form-control"
+                            tal:attributes="name string:samples.other_reasons:records"></textarea>
+                </div>
+
+              </div>
+            </div>
+          </tal:samples>
+
+          <!-- Form Controls -->
+          <div>
+            <!-- Cancel -->
+            <input class="btn btn-secondary btn-sm"
+                   type="submit"
+                   name="button_cancel"
+                   i18n:attributes="value"
+                   value="Cancel"/>
+            <!-- Continue -->
+            <input class="btn btn-danger btn-sm"
+                   type="submit"
+                   name="button_continue"
+                   i18n:attributes="value"
+                   value="Reject"/>
+          </div>
+        </form>
+      </div>
+    </metal:core>
+  </body>
+</html>

--- a/src/senaite/referral/browser/inbound/samples/rejection/templates/reject_inbound_samples.pt
+++ b/src/senaite/referral/browser/inbound/samples/rejection/templates/reject_inbound_samples.pt
@@ -81,7 +81,7 @@
                   </label>
                   <div tal:condition="reasons" tal:repeat="reason reasons">
                     <input type="checkbox"
-                           tal:attributes="name string:samples.reasons:records:list;
+                           tal:attributes="name string:inbound_samples.reasons:records:list;
                                            value reason"/>
                     <span tal:content="reason"></span>
                   </div>
@@ -102,7 +102,7 @@
                     Rejection reasons
                   </label>
                   <textarea rows="5" class="form-control"
-                            tal:attributes="name string:samples.other_reasons:records"></textarea>
+                            tal:attributes="name string:inbound_samples.other_reasons:records"></textarea>
                 </div>
 
               </div>

--- a/src/senaite/referral/browser/inbound/samples/view.py
+++ b/src/senaite/referral/browser/inbound/samples/view.py
@@ -15,7 +15,7 @@
 # this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# Copyright 2021-2022 by it's authors.
+# Copyright 2021-2025 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
 import collections
@@ -115,15 +115,16 @@ class SamplesListingView(ListingView):
                 },
                 "custom_transitions": [print_stickers],
                 "columns": self.columns.keys(),
-            }, {
+            },
+            {
                 "id": "rejected",
                 "title": _("Rejected"),
                 "contentFilter": {
                     "review_state": "rejected",
                 },
-                "custom_transitions": [],
                 "columns": self.columns.keys(),
-            }, {
+            },
+            {
                 "id": "all",
                 "title": _("All"),
                 "contentFilter": {},

--- a/src/senaite/referral/browser/viewlets/configure.zcml
+++ b/src/senaite/referral/browser/viewlets/configure.zcml
@@ -52,4 +52,15 @@
       permission="zope2.View"
       layer="senaite.referral.interfaces.ISenaiteReferralLayer" />
 
+
+  <!-- Rejected Inbound Samples viewlet -->
+  <browser:viewlet
+      for="senaite.referral.interfaces.IInboundSampleShipment"
+      name="senaite.referral.viewlet.rejected_inbound_samples"
+      class=".inboundsample.RejectedInboundSamplesViewlet"
+      manager="plone.app.layout.viewlets.interfaces.IAboveContent"
+      template="templates/rejected_inbound_samples_viewlet.pt"
+      permission="zope2.View"
+      layer="senaite.referral.interfaces.ISenaiteReferralLayer" />
+    
 </configure>

--- a/src/senaite/referral/browser/viewlets/inboundsample.py
+++ b/src/senaite/referral/browser/viewlets/inboundsample.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of SENAITE.REFERRAL.
+#
+# SENAITE.REFERRAL is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the Free
+# Software Foundation, version 2.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright 2021-2025 by it's authors.
+# Some rights reserved, see README and LICENSE.
+
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from bika.lims import api
+from plone.app.layout.viewlets import ViewletBase
+from plone.memoize import view
+from senaite.referral import check_installed
+from senaite.referral.catalog import INBOUND_SAMPLE_CATALOG
+
+
+class RejectedInboundSamplesViewlet(ViewletBase):
+    """Current Inbound Samples were rejected. Display the reasons
+    """
+    template = ViewPageTemplateFile("templates/rejected_inbound_samples_viewlet.pt")  # noqa: E501
+
+    @check_installed(False)
+    def is_visible(self):
+        """Returns whether the viewlet must be visible or not
+        """
+        rejected_inbound_samples = self.get_rejected_inbound_samples()
+        if not rejected_inbound_samples:
+            return False
+
+        return True
+
+    def get_rejected_inbound_samples(self):
+        """Returns the rejected inbound samples
+        """
+        query = dict(
+            portal_type="InboundSample",
+            path=dict(query=api.get_path(self.context), level=0),
+            review_state="rejected")
+        brains = api.search(query, INBOUND_SAMPLE_CATALOG)
+        return [api.get_object(brain) for brain in brains]
+
+    @view.memoize
+    def has_reasons(self, inbound_sample):
+        """Returns whether the sample has reasons or not
+        """
+        return (
+            inbound_sample.getSelectedRejectionReasons() or
+            inbound_sample.getOtherRejectionReasons()
+        )

--- a/src/senaite/referral/browser/viewlets/templates/rejected_inbound_samples_viewlet.pt
+++ b/src/senaite/referral/browser/viewlets/templates/rejected_inbound_samples_viewlet.pt
@@ -1,0 +1,29 @@
+<div tal:omit-tag=""
+     tal:condition="python:view.is_visible()"
+     i18n:domain="senaite.referral">
+
+  <div class="visualClear"></div>
+
+  
+  <div id="portal-alert" tal:define="sample python:view.context">
+    <div class="portlet-alert-item alert alert-warning alert-dismissible">
+      <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+      </button>
+      <strong class="bigger" i18n:translate="">Rejected Inbound Samples</strong>
+      <tal:samples repeat="inbound_sample view/get_rejected_inbound_samples">
+        <p class="title">
+            <span i18n:translate="" tal:condition="python:view.has_reasons(inbound_sample)">Sample <tal:sample tal:replace="inbound_sample/Title"/> has been rejected due to the following reasons: </span>
+            <span i18n:translate="" tal:condition="python:not view.has_reasons(inbound_sample)">Sample <tal:sample tal:replace="inbound_sample/Title"/> has been rejected</span>
+        </p>
+        <ul tal:define="reasons python:inbound_sample.getSelectedRejectionReasons()" tal:condition="reasons">
+            <li tal:repeat="reason reasons" tal:content="reason"></li>
+        </ul>
+        <ul tal:define="other_reasons python:inbound_sample.getOtherRejectionReasons()"
+            tal:condition="other_reasons">
+            <li i18n:translate="">Other reasons: <span tal:content="structure other_reasons"></span></li>
+        </ul>
+      </tal:samples>
+    </div>
+  </div>
+</div>

--- a/src/senaite/referral/browser/workflow/configure.zcml
+++ b/src/senaite/referral/browser/workflow/configure.zcml
@@ -38,4 +38,15 @@
       provides="bika.lims.interfaces.IWorkflowActionAdapter"
       permission="zope.Public" />
 
+  <!-- Inbound Samples: "reject"
+  Redirects to the reject inbound samples view
+  -->
+  <adapter 
+    name="reject_inbound_sample"
+    for="senaite.app.listing.interfaces.IAjaxListingView
+         *
+         senaite.referral.interfaces.ISenaiteReferralLayer"
+    provides="senaite.app.listing.interfaces.IListingWorkflowTransition"
+    factory=".inboundsample.InboundSampleRejectWorkflowTransition" />
+
 </configure>

--- a/src/senaite/referral/browser/workflow/inboundsample.py
+++ b/src/senaite/referral/browser/workflow/inboundsample.py
@@ -18,6 +18,8 @@
 # Copyright 2021-2022 by it's authors.
 # Some rights reserved, see README and LICENSE.
 
+from senaite.app.listing.adapters.workflow import ListingWorkflowTransition
+from senaite.app.listing.interfaces import IListingWorkflowTransition
 from senaite.referral import messageFactory as _
 from senaite.referral import PRODUCT_NAME
 from senaite.referral.workflow import do_queue_or_action_for
@@ -25,6 +27,7 @@ from senaite.referral.workflow import do_queue_or_action_for
 from bika.lims import api
 from bika.lims import senaiteMessageFactory as _s
 from bika.lims.browser.workflow import WorkflowActionGenericAdapter
+from zope.interface import implementer
 
 
 class WorkflowActionReceiveAdapter(WorkflowActionGenericAdapter):
@@ -68,3 +71,32 @@ class WorkflowActionReceiveAdapter(WorkflowActionGenericAdapter):
         """
         key = "{}.barcodes_preview_reception".format(PRODUCT_NAME)
         return api.get_registry_record(key, default=False)
+
+
+@implementer(IListingWorkflowTransition)
+class InboundSampleRejectWorkflowTransition(ListingWorkflowTransition):
+    """Adapter in charge of InboundSample's 'reject' action
+    """
+    def __init__(self, view, context, request):
+        super(InboundSampleRejectWorkflowTransition, self).__init__(
+            view, context, request)
+        self.back_url = self.context.absolute_url()
+        self.chained_uids = []
+
+    def do_transition(
+        self, transition, chained_uids, failed_transitions, **kw
+    ):
+        """Execute the workflow transition
+        """
+        super(InboundSampleRejectWorkflowTransition, self).do_transition(
+            transition, chained_uids, failed_transitions, **kw)
+        self.chained_uids = chained_uids
+
+    def get_redirect_url(self):
+        """Redirect after reject_inbound_sample transition
+        """
+        uids = ",".join(self.chained_uids)
+        url = "{}/reject_inbound_samples?uids={}".format(
+            self.back_url, uids
+        )
+        return url

--- a/src/senaite/referral/configure.zcml
+++ b/src/senaite/referral/configure.zcml
@@ -31,6 +31,10 @@
       component="senaite.referral.vocabularies.ReferenceLaboratoriesVocabularyFactory"
       name="senaite.referral.vocabularies.referencelaboratories" />
 
+  <utility
+      component="senaite.referral.vocabularies.RejectionReasonsVocabularyFactory"
+      name="senaite.referral.vocabularies.rejection_reasons" />
+
 
   <!-- Default profile -->
   <genericsetup:registerProfile

--- a/src/senaite/referral/content/inboundsample.py
+++ b/src/senaite/referral/content/inboundsample.py
@@ -35,6 +35,7 @@ from senaite.referral.content import set_string_value
 from senaite.referral.content import set_uids_field_value
 from senaite.referral.interfaces import IInboundSample
 from senaite.referral.utils import get_action_date
+from z3c.form.browser.checkbox import CheckBoxFieldWidget
 from zope import schema
 from zope.interface import implementer
 from zope.interface import Invalid
@@ -46,7 +47,7 @@ from bika.lims import api
 def is_referring_id_unique(instance, referring_id):
     """Checks whether the referring id passed-in is unique
     """
-    query = {"portal_type": "InboundSample", "referring_id": referring_id }
+    query = {"portal_type": "InboundSample", "referring_id": referring_id}
     brains = api.search(query, catalog=INBOUND_SAMPLE_CATALOG)
     if not brains:
         return True
@@ -139,6 +140,21 @@ class IInboundSampleSchema(model.Schema):
             u"Sample record automatically generated in current instance after "
             u"receiving the inbound sample"
         )
+    )
+
+    selected_rejection_reasons = schema.Set(
+        title=_("Selected rejection reasons for inbound sample"),
+        value_type=schema.Choice(
+            vocabulary="senaite.referral.vocabularies.rejection_reasons"
+        ),
+        required=False,
+    )
+    directives.widget('selected_rejection_reasons', CheckBoxFieldWidget)
+
+    other_rejection_reasons = schema.Text(
+        title=_("Other rejection reasons"),
+        description=_("Describe other rejection reasons not predefined"),
+        required=False,
     )
 
     @invariant
@@ -335,3 +351,23 @@ class InboundSample(Container):
         with the analyses that were requested by the referring laboratory
         """
         return get_uids_field_value(self, "services") or []
+
+    def setSelectedRejectionReasons(self, value):
+        """Sets the selected rejection reasons
+        """
+        set_string_list_value(self, "selected_rejection_reasons", value)
+
+    def getSelectedRejectionReasons(self):
+        """Returns a list with the selected rejection reasons, if any
+        """
+        return get_string_list_value(self, "selected_rejection_reasons")
+
+    def setOtherRejectionReasons(self, value):
+        """Sets other rejection reasons custom text
+        """
+        set_string_value(self, "other_rejection_reasons", value)
+
+    def getOtherRejectionReasons(self):
+        """Returns other rejection reasons custom text, if any
+        """
+        return get_string_value(self, "other_rejection_reasons")

--- a/src/senaite/referral/vocabularies.py
+++ b/src/senaite/referral/vocabularies.py
@@ -69,3 +69,18 @@ class ReferenceLaboratoriesVocabulary(object):
 
 
 ReferenceLaboratoriesVocabularyFactory = ReferenceLaboratoriesVocabulary()
+
+
+@implementer(IVocabularyFactory)
+class RejectionReasonsVocabulary(object):
+    """Vocabulary factory for rejection reasons
+    """
+
+    def __call__(self, context):
+        items = api.get_setup().getRejectionReasonsItems()
+        return SimpleVocabulary(
+            [SimpleTerm(item, item, item) for item in items]
+        )
+
+
+RejectionReasonsVocabularyFactory = RejectionReasonsVocabulary()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
Implements support for rejecting InboundSample objects with assigned rejection reasons. This enhancement ensures users can provide reasons for rejecting inbound samples and allows batch rejection through a dedicated view

## Current behavior before PR

- InboundSample objects could be rejected without specifying rejection reasons
- No dedicated view to enter rejection reasons for multiple samples
- Do not show viewlet for rejected samples

## Desired behavior after PR is merged

- InboundSample type includes a new field `selected_rejection_reasons` and `other_rejection_reasons`
- Clicking "Reject" in the Inbound Sample listing redirects users to a view where they can enter rejection reasons for one or more samples
<img width="1449" alt="image" src="https://github.com/user-attachments/assets/868b4736-6a75-40ff-bf3e-08f964bb8f49" />

- Show reasons in viewlet for rejected inbound samples
<img width="1460" alt="image" src="https://github.com/user-attachments/assets/c88ca359-4ecb-42a1-8bf0-00f9a4068a2e" />


--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
