### PR TITLE
Fix referred samples do not transition to "received at reference"

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (Unreleased)
 ------------------
 
+- #38 Fix referred samples do not transition to "received at reference"
 - #37 Allow to set the default sorting order for samples in outbound shipments
 - #36 Enable configuration for notifying about retested and hidden analyses
 - #32 Fix build test after adding default contact

--- a/src/senaite/referral/workflow/analysisrequest.py
+++ b/src/senaite/referral/workflow/analysisrequest.py
@@ -58,9 +58,6 @@ def AfterTransitionEventHandler(sample, event): # noqa lowercase
     if event.transition.id == "recall_from_shipment":
         restore_referred_sample(sample)
 
-    if event.transition.id == "receive":
-        after_receive(sample)
-
 
 def after_no_sampling_workflow(sample):
     """Automatically receive and ship samples for which an outbound shipment
@@ -135,16 +132,6 @@ def after_invalidate(sample):
     if referring:
         # notify the referring laboratory
         referring.do_action(sample, "invalidate_at_reference")
-
-
-def after_receive(sample):
-    """Actions to do when receiving a sample
-    """
-    shipment = sample.getInboundShipment()
-    referring = get_remote_lab(shipment)
-    if referring:
-        # notify the referring laboratory
-        referring.do_action(sample, "receive_at_reference")
 
 
 def after_invalidate_at_reference(sample):

--- a/src/senaite/referral/workflow/inboundsample/events.py
+++ b/src/senaite/referral/workflow/inboundsample/events.py
@@ -46,13 +46,12 @@ def after_receive_inbound_sample(inbound_sample):
         receive_sample(sample)
 
     # Notify the referring laboratory about the sample's reception
-    shipment = sample.getInboundShipment()
+    shipment = inbound_sample.getInboundShipment()
     referring = get_remote_lab(shipment)
     if referring:
         referring.do_action(sample, "receive_at_reference")
 
     # Try with the whole shipment
-    shipment = inbound_sample.getInboundShipment()
     doActionFor(shipment, "receive_inbound_shipment")
 
 

--- a/src/senaite/referral/workflow/inboundsample/events.py
+++ b/src/senaite/referral/workflow/inboundsample/events.py
@@ -19,10 +19,13 @@
 # Some rights reserved, see README and LICENSE.
 
 from bika.lims import api
+from bika.lims.interfaces import IReceived
 from bika.lims.utils.analysisrequest import create_analysisrequest
+from bika.lims.utils.analysisrequest import receive_sample
 from bika.lims.workflow import doActionFor
 from senaite.referral.utils import get_sample_types_mapping
 from senaite.referral.utils import get_services_mapping
+from senaite.referral.workflow.analysisrequest import get_remote_lab
 
 
 def after_receive_inbound_sample(inbound_sample):
@@ -38,8 +41,15 @@ def after_receive_inbound_sample(inbound_sample):
     # Create the sample
     sample = create_sample(inbound_sample)
 
-    # Auto-receive the sample object
-    doActionFor(sample, "receive")
+    # Always auto-receive samples from inbound shipments
+    if not IReceived.providedBy(sample):
+        receive_sample(sample)
+
+    # Notify the referring laboratory about the sample's reception
+    shipment = sample.getInboundShipment()
+    referring = get_remote_lab(shipment)
+    if referring:
+        referring.do_action(sample, "receive_at_reference")
 
     # Try with the whole shipment
     shipment = inbound_sample.getInboundShipment()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When the reference laboratory has the "Auto-receive samples" setting enabled, the referring laboratory is not notified about the sample's reception in the reference lab. Consequently, the sample's status remains as "referred" in the referring lab, while it is flagged as "received" in the reference lab.

This occurs because the "receive" transition is not triggered upon sample creation; instead, [the status is updated manually](https://github.com/senaite/senaite.core/blob/b18a4cadb75c2d0db7620feb059b11e0fbead00e/src/bika/lims/utils/analysisrequest.py#L147). As a result, [the event associated with the receive transition](https://github.com/senaite/senaite.referral/blob/ffcddf553cc04004e880b1ec363fdf332fd77e8f/src/senaite/referral/workflow/analysisrequest.py#L140-L147) is never executed.

This Pull Request fixes this problem by manually triggering the notification when receiving the inbound sample.

## Current behavior before PR

Referred samples are not transitioned from `referred` to `received at reference` when received in the reference lab.

## Desired behavior after PR is merged

Referred samples are transitioned from `referred` to `received at reference` when received in the reference lab.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
