### PR TITLE
Compatibility with core#2835 (display Shipments in navbar)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (Unreleased)
 ------------------
 
+- #39 Compatibility with core#2835 (display Shipments in navbar)
 - #38 Fix referred samples do not transition to "received at reference"
 - #37 Allow to set the default sorting order for samples in outbound shipments
 - #36 Enable configuration for notifying about retested and hidden analyses

--- a/src/senaite/referral/profiles/default/metadata.xml
+++ b/src/senaite/referral/profiles/default/metadata.xml
@@ -6,7 +6,7 @@
   dependencies before installing this add-on own profile.
 -->
 <metadata>
-  <version>2009</version>
+  <version>2010</version>
 
   <!-- Be sure to install the following dependencies if not yet installed -->
   <dependencies>

--- a/src/senaite/referral/setuphandlers.py
+++ b/src/senaite/referral/setuphandlers.py
@@ -20,8 +20,8 @@
 
 from collections import OrderedDict
 
+from bika.lims import api
 from bika.lims.api import UID_CATALOG
-from plone.registry.interfaces import IRegistry
 from senaite.core.api.workflow import update_workflow
 from senaite.core.registry import get_registry_record
 from senaite.core.registry import set_registry_record
@@ -37,7 +37,6 @@ from senaite.referral.config import AJAX_TRANSITIONS
 from senaite.referral.config import PRODUCT_NAME
 from senaite.referral.config import PROFILE_ID
 from senaite.referral.config import UNINSTALL_ID
-from zope.component import getUtility
 
 CATALOGS = (
     InboundSampleCatalog,
@@ -58,11 +57,6 @@ COLUMNS = [
 PORTAL_FOLDERS = [
     ("external_labs", "External laboratories", "ExternalLaboratoryFolder"),
     ("shipments", "Shipments", "ShipmentFolder"),
-]
-
-NAVTYPES = [
-    "ExternalLaboratoryFolder",
-    "ShipmentFolder",
 ]
 
 WORKFLOWS_TO_UPDATE = {
@@ -215,9 +209,6 @@ def setup_handler(context):
     # Portal folders
     add_portal_folders(portal)
 
-    # Configure visible navigation items
-    setup_navigation_types(portal)
-
     # Setup worlflows
     setup_workflows(portal)
 
@@ -278,21 +269,40 @@ def add_portal_folders(portal):
     logger.info("Adding portal folders ...")
     for folder_id, folder_name, portal_type in PORTAL_FOLDERS:
         if portal.get(folder_id) is None:
-            portal.invokeFactory(portal_type, folder_id, title=folder_name)
+            logger.info("Adding folder: {}".format(folder_id))
+            params = dict(id=folder_id, title=folder_name)
+            api.create(portal, portal_type, **params)
+
+    # make folders visible in the navigation bar
+    for folder_id, folder_name, portal_type in PORTAL_FOLDERS:
+        obj = portal.get(folder_id)
+        if obj is not None:
+            display_in_nav(obj)
 
     logger.info("Adding portal folders [DONE]")
 
 
-def setup_navigation_types(portal):
-    """Add additional types for navigation
+def display_in_nav(obj):
+    """Makes an object to be displayed in the navigation bar
     """
-    registry = getUtility(IRegistry)
-    key = "plone.displayed_types"
-    display_types = registry.get(key, ())
+    portal_type = api.get_portal_type(obj)
 
-    new_display_types = set(display_types)
-    new_display_types.update(NAVTYPES)
-    registry[key] = tuple(new_display_types)
+    # remove from senaite setup's sidebar_skip_types
+    setup = api.get_senaite_setup()
+    skip = setup.getSidebarSkipTypes()
+    if skip and portal_type in skip:
+        skip = tuple(pt for pt in skip if pt != portal_type)
+        setup.setSidebarSkipTypes(skip)
+
+    # if a root folder, add to senaite setup's sidebar_folders
+    setup = api.get_senaite_setup()
+    portal = api.get_portal()
+    if api.get_parent(obj) == portal:
+        obj_id = api.get_id(obj)
+        folders = setup.getSidebarFolders()
+        if obj_id not in folders:
+            folders += (obj_id, )
+            setup.setSidebarFolders(folders)
 
 
 def setup_workflows(portal):

--- a/src/senaite/referral/subscribers/upgrade.py
+++ b/src/senaite/referral/subscribers/upgrade.py
@@ -23,7 +23,6 @@ from senaite.referral import logger
 from senaite.referral import PRODUCT_NAME
 from senaite.referral.setuphandlers import setup_catalogs
 from senaite.referral.setuphandlers import setup_workflows
-from senaite.referral.setuphandlers import setup_navigation_types
 
 
 def afterUpgradeStepHandler(event):  # noqa CamelCase
@@ -44,8 +43,5 @@ def afterUpgradeStepHandler(event):  # noqa CamelCase
 
     # Setup workflows
     setup_workflows(portal)
-
-    # Setup navigation tpyes
-    setup_navigation_types(portal)
 
     logger.info("Run {}.afterUpgradeStepHandler [DONE]".format(PRODUCT_NAME))

--- a/src/senaite/referral/tests/doctests/ReferralNavigation.rst
+++ b/src/senaite/referral/tests/doctests/ReferralNavigation.rst
@@ -1,0 +1,98 @@
+Referral Navigation Bar Visibility
+===================================
+
+This test ensures that the Shipments and External Labs folders are visible in
+the navigation bar after installation, in accordance with the new sidebar
+navigation system introduced in senaite.core.
+
+Running this test from the buildout directory:
+
+    bin/test -m senaite.referral -t ReferralNavigation
+
+
+Test Setup
+..........
+
+Needed Imports:
+
+    >>> from bika.lims import api
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import TEST_USER_ID
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> setup = api.get_senaite_setup()
+
+Assign default roles for the user to test with:
+
+    >>> setRoles(portal, TEST_USER_ID, ['LabManager',])
+
+
+Shipments Folder Navigation Visibility
+---------------------------------------
+
+After installation, the Shipments folder should be visible in the navigation
+bar. This is configured through two mechanisms:
+
+1. The portal type "ShipmentFolder" should NOT be in SENAITE Setup's
+   sidebar_skip_types (types in this list are excluded from the sidebar):
+
+    >>> sidebar_skip_types = setup.getSidebarSkipTypes()
+    >>> sidebar_skip_types is not None
+    True
+    >>> "ShipmentFolder" not in sidebar_skip_types
+    True
+
+2. Since the shipments folder is a root folder (direct child of portal), its
+   ID should be in SENAITE Setup's sidebar_folders:
+
+    >>> sidebar_folders = setup.getSidebarFolders()
+    >>> sidebar_folders is not None
+    True
+    >>> "shipments" in sidebar_folders
+    True
+
+Verify the shipments folder exists and is properly configured:
+
+    >>> shipments = portal.shipments
+    >>> shipments is not None
+    True
+
+    >>> api.get_portal_type(shipments)
+    'ShipmentFolder'
+
+    >>> api.get_parent(shipments) == portal
+    True
+
+
+External Labs Folder Navigation Visibility
+--------------------------------------------
+
+After installation, the External Labs folder should be visible in the
+navigation bar:
+
+1. The portal type "ExternalLaboratoryFolder" should NOT be in SENAITE Setup's
+   sidebar_skip_types:
+
+    >>> "ExternalLaboratoryFolder" not in sidebar_skip_types
+    True
+
+2. Since the external_labs folder is a root folder, its ID should be in
+   SENAITE Setup's sidebar_folders:
+
+    >>> "external_labs" in sidebar_folders
+    True
+
+Verify the external_labs folder exists and is properly configured:
+
+    >>> external_labs = portal.external_labs
+    >>> external_labs is not None
+    True
+
+    >>> api.get_portal_type(external_labs)
+    'ExternalLaboratoryFolder'
+
+    >>> api.get_parent(external_labs) == portal
+    True

--- a/src/senaite/referral/upgrade/v02_00_000.py
+++ b/src/senaite/referral/upgrade/v02_00_000.py
@@ -29,6 +29,8 @@ from senaite.referral import PRODUCT_NAME
 from senaite.referral.catalog import INBOUND_SAMPLE_CATALOG
 from senaite.referral.catalog import SHIPMENT_CATALOG
 from senaite.referral.config import PRODUCT_NAME as product
+from senaite.referral.setuphandlers import display_in_nav
+from senaite.referral.setuphandlers import PORTAL_FOLDERS
 from senaite.referral.setuphandlers import setup_ajax_transitions
 from senaite.referral.setuphandlers import setup_workflows
 from senaite.referral.utils import get_notify_unrequested
@@ -205,3 +207,15 @@ def setup_outbound_samples_order(tool):
     setup = portal.portal_setup
     setup.runImportStepFromProfile(profile, "plone.app.registry")
     logger.info("Setup order of outbound samples [DONE]")
+
+
+def display_folders_navbar(tool):
+    """Displays Shipments and External Labs folders in the navigation bar
+    """
+    logger.info("Display folders in navigation bar ...")
+    portal = api.get_portal()
+    folders = [portal.get(folder[0]) for folder in PORTAL_FOLDERS]
+    for folder in folders:
+        if folder is not None:
+            display_in_nav(folder)
+    logger.info("Display folders in navigation bar [DONE]")

--- a/src/senaite/referral/upgrade/v02_00_000.zcml
+++ b/src/senaite/referral/upgrade/v02_00_000.zcml
@@ -3,6 +3,18 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
+      title="Display Shipments and External Labs in the navbar"
+      description="
+        This upgrade step makes the product compatible with senaite.core#2835
+        by adding Shipments and External Labs folders to the setup field
+        'Sidebar displayed portal types', thereby displaying them in the
+        left-hand navigation bar."
+      source="2009"
+      destination="2010"
+      handler=".v02_00_000.display_folders_navbar"
+      profile="senaite.referral:default"/>
+
+  <genericsetup:upgradeStep
       title="SENAITE.REFERRAL 2.0.0: Setup outbound samples sorting config"
       description="Setup outbound samples sorting config"
       source="2008"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

> [!IMPORTANT]
> Requires:
> - https://github.com/senaite/senaite.core/pull/2835

This Pull Request makes this product compatible with https://github.com/senaite/senaite.core/pull/2835

## Current behavior before PR

Shipments folder is not visible in the navigation bar after core's upgrade 2718

## Desired behavior after PR is merged

Shipments folder is visible in the navigation bar after core's upgrade 2718

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
