### PR TITLE
Compatibility with core#2810 (Laboratory to DX)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (Unreleased)
 ------------------
 
+- #40 Compatibility with core#2810 (Laboratory to DX)
 - #39 Compatibility with core#2835 (display Shipments in navbar)
 - #38 Fix referred samples do not transition to "received at reference"
 - #37 Allow to set the default sorting order for samples in outbound shipments

--- a/src/senaite/referral/browser/shipment_manifest.py
+++ b/src/senaite/referral/browser/shipment_manifest.py
@@ -111,7 +111,9 @@ class ShipmentManifestTemplate(BaseView):
     def laboratory(self):
         """Laboratory object from the LIMS setup
         """
-        return api.get_setup().laboratory
+        # Laboratory was migrated to Dexterity in senaite.core 2.7 and
+        # now lives under `portal.setup` instead of `portal.bika_setup`.
+        return api.get_senaite_setup().laboratory
 
     @property
     def shipment(self):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes this product compatible with [Migrate Laboratory to DX #2810](https://github.com/senaite/senaite.core/pull/2810)


## Current behavior before PR

```
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module senaite.referral.browser.shipment_manifest, line 68, in __call__
  Module senaite.referral.browser.shipment_manifest, line 91, in generate_manifest
  Module Products.Five.browser.pagetemplatefile, line 126, in __call__
  Module Products.Five.browser.pagetemplatefile, line 61, in __call__
  Module zope.pagetemplate.pagetemplate, line 135, in pt_render
  Module Products.PageTemplates.engine, line 378, in __call__
  Module z3c.pt.pagetemplate, line 176, in render
  Module chameleon.zpt.template, line 302, in render
  Module chameleon.template, line 215, in render
  Module chameleon.template, line 192, in render
  Module 118fbe775b27b63a99640e5a05d9d569, line 181, in render
  Module zope.tales.pythonexpr, line 73, in __call__
   - __traceback_info__: (view.laboratory)
  Module <string>, line 1, in <module>
  Module senaite.referral.browser.shipment_manifest, line 114, in laboratory
AttributeError: 'RequestContainer' object has no attribute 'laboratory'

 - Expression: " python:view.laborator"
 - Filename:   ... referral/browser/templates/shipment_manifest_template.pt
 - Location:   (line 4: col 28)
 - Source:     laboratory python:view.laboratory;
                         ^^^^^^^^^^^^^^^^^^^^^^
 - Arguments:  repeat: <Products.PageTemplates.engine.RepeatDictWrapper object at 0x7fbdf319a730>
               template: <Products.Five.browser.pagetemplatefile.ViewPageTemplateFile object at 0x7fbe32971910>
               views: <Products.Five.browser.pagetemplatefile.ViewMapper object at 0x7fbe00d90ed0>
               request: <WSGIRequest, URL=https://tphl-lims.carpha.org/external_labs/externallaboratory-1/CAR26AA058/shipment_manifest>
               args: ()
               here: <OutboundSampleShipment at /senaite/external_labs/externallaboratory-1/CAR26AA058>
               user: <PloneUser u'me@example.com'>
               nothing: None
               translate: <function translate at 0x7fbdf3694ed0>
               container: <OutboundSampleShipment at /senaite/external_labs/externallaboratory-1/CAR26AA058>
               modules: <Products.PageTemplates.ZRPythonExpr._SecureModuleImporter object at 0x7fbe42d71cd0>
               portal_url: <URLTool at /senaite/portal_url used for /senaite/external_labs/externallaboratory-1/CAR26AA058>
               traverse_subpath: []
               default: <DEFAULT>
               loop: {}
               context: <OutboundSampleShipment at /senaite/external_labs/externallaboratory-1/CAR26AA058>
               view: <senaite.referral.browser.shipment_manifest.ShipmentManifestTemplate object at 0x7fbdf8dec810>
               target_language: 'en'
               root: <Application at >
               options: {}
               attrs: {u'xmlns': u'http://www.w3.org/1999/xhtml'}
```

## Desired behavior after PR is merged

No traceback on shipment manifest creation

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
