### PR TITLE
Compatibility with core#2962 (Remove RegulatoryInspector)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 2.0.0 (Unreleased)
 ------------------
 
+- #41 Compatibility with core#2962 (Remove RegulatoryInspector)
 - #40 Compatibility with core#2810 (Laboratory to DX)
 - #39 Compatibility with core#2835 (display Shipments in navbar)
 - #38 Fix referred samples do not transition to "received at reference"

--- a/src/senaite/referral/profiles/default/workflows/senaite_referral_folder_workflow/definition.xml
+++ b/src/senaite/referral/profiles/default/workflows/senaite_referral_folder_workflow/definition.xml
@@ -24,7 +24,6 @@
       <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
       <permission-role>Preserver</permission-role>
-      <permission-role>RegulatoryInspector</permission-role>
       <permission-role>Sampler</permission-role>
       <permission-role>SamplingCoordinator</permission-role>
       <!-- Plone roles -->
@@ -38,7 +37,6 @@
       <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
       <permission-role>Preserver</permission-role>
-      <permission-role>RegulatoryInspector</permission-role>
       <permission-role>Sampler</permission-role>
       <permission-role>SamplingCoordinator</permission-role>
       <!-- Plone roles -->
@@ -56,7 +54,6 @@
       <permission-role>LabClerk</permission-role>
       <permission-role>LabManager</permission-role>
       <permission-role>Preserver</permission-role>
-      <permission-role>RegulatoryInspector</permission-role>
       <permission-role>Sampler</permission-role>
       <permission-role>SamplingCoordinator</permission-role>
       <!-- Plone roles -->


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

> [!IMPORTANT]
> Requires:
> - https://github.com/senaite/senaite.core/pull/2962

This Pull Request makes this product compatible with https://github.com/senaite/senaite.core/pull/2962

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
